### PR TITLE
chore: .gitignore に Claude Code・Windows 関連エントリを追加 (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,10 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+# Claude Code
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.pr-creation-authorized
+
+# Windows
+bash.exe.stackdump


### PR DESCRIPTION
## Change type

- [x] chore（設定・雑務）

## Summary

- `.claude/settings.local.json` を追加（ローカル設定の漏洩防止）
- `.claude/scheduled_tasks.lock` を追加（スケジュールロック）
- `.pr-creation-authorized` を追加（認可フラグ）
- `bash.exe.stackdump` を追加（Windows bash クラッシュダンプ）

## Test plan

- [x] `.gitignore` のみの変更、コード影響なし

## Related issues

Closes #7