### PR TITLE
chore: .markdownlint-cli2.jsonc を他リポジトリ準拠で追加 (#14)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "MD013": {
+      "line_length": 200,
+      "code_blocks": false,
+      "tables": false
+    },
+    "MD024": false,
+    "MD029": false,
+    "MD036": false,
+    "MD040": false,
+    "MD041": false,
+    "MD060": false
+  },
+  "ignores": [],
+  "globs": [
+    "docs/**/*.md",
+    "*.md",
+    ".claude/**/*.md",
+    ".github/prompts/*.md"
+  ]
+}


### PR DESCRIPTION
## Change type

- [x] chore (lint 設定ファイル追加)

## Summary

- `.markdownlint-cli2.jsonc` をリポジトリルートに新規追加（ai-assistant 準拠）
- config: `MD013` line_length=200/code_blocks/tables 除外、`MD024/029/036/040/041/060` 無効化のみ
- globs: `docs/**/*.md` / `*.md` / `.claude/**/*.md` / `.github/prompts/*.md`
- 設定追加によるルール緩和は Issue #14 で明示指定された範囲のみ。追加の無効化（MD033 等）は持ち込んでいない

## Test plan

- [x] `npx markdownlint-cli2@0.20.0` 実行で全 9 ファイル / 0 errors を確認

## Related issues

Closes #14