### PR TITLE
diary: 2026-02-10 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-10-diary.md
+++ b/articles/hatena/2026-02-10-diary.md
@@ -1,0 +1,207 @@
+---
+title: "終了時のエラー片付けと、リーダーがキャラを忘れた話"
+date: "2026-02-10"
+category: "diary"
+---
+
+# 終了時のエラー片付けと、リーダーがキャラを忘れた話
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>後片付け系の作業、けっこう好きかもしれません。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>リーダー業ってさ、自分の足元から崩れがちなのよね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>今日も PR の数を自慢げに数えているらしい。</div>
+</div>
+</div>
+
+## Ctrl+C で出ていたエラーを片付けた話
+
+nee-san>>おはよ。コーヒー、もう淹れてあるよ。
+
+kuro-chan>>おはようございます、幸田姉さん。あ、ありがとうございます……。
+
+nee-san>>今日のお題ね、`ai-assistant` の終了時エラーを直すやつ。
+
+kuro-chan>>終了時、というと。
+
+nee-san>>Ctrl+C で止めると、毎回赤い文字でいくつかエラーが出てたの。動きとしては止まってるんだけど、見た目がうるさい。
+
+kuro-chan>>あ、止まってはいるんですね。
+
+nee-san>>うん。中身としては、外につないでた回線を閉じる処理が呼ばれずに残ってた。
+
+kuro-chan>>閉じてないと、`Unclosed client session` みたいなのが出るやつ、ですか。
+
+nee-san>>そう、よく知ってんね。
+
+kuro-chan>>本では、見たことはあって……。
+
+nee-san>>で、直し方は、回線をつなぐところを「使い終わったら自動で閉じる箱」に入れる、っていうやつ。
+
+kuro-chan>>あ、`async with` で囲うパターンですか。
+
+nee-san>>そう。終わるときに必ず閉じる側を通るように、`finally` で押さえる形にした。
+
+kuro-chan>>なるほど。出入り口を 1 本にまとめておくと、忘れにくいですね。
+
+nee-san>>そう。出口が複数あると、どれかが閉じ忘れる。
+
+kuro-chan>>うちでも、同じパターンで使い回せそうですね。データベースとか、外の API とか。
+
+nee-san>>うん、まぁそれは追々ね。
+
+## 「やらない」って言ったやつ、結局やった話
+
+nee-san>>でね、ちょっと気まずい話なんだけど。
+
+kuro-chan>>はい。
+
+nee-san>>今回、計画の段階で「これはやらない」って線引いた項目があってさ。`CancelledError` の、長い追跡記録が出るやつ。
+
+kuro-chan>>追跡記録、っていうと、`Traceback` のやつですか。
+
+nee-san>>そう。実害はないから、今回は触らないって決めて、社長にも一回 OK もらったの。
+
+kuro-chan>>はい、はい。
+
+nee-san>>で、いざ直したのを見せたら、社長が「いや、これ気になるから消したい」って。
+
+kuro-chan>>あ、それは……。
+
+nee-san>>ね。事前に「やらない」って合意したのに、結局やる側になった。
+
+kuro-chan>>でも、見た目が気になる、っていうのは、わかります……。
+
+nee-san>>うん、わかるのよ。実害がないって言っても、毎回ターミナルに長文が流れてくるのは、誰だって嫌よ。
+
+kuro-chan>>「実害なし」と「気にならない」は、別物、っていうことですか。
+
+nee-san>>そういうこと。線の引き方が甘かった、って話。最初から「見た目の問題まで含めるか」って聞いとくべきだった。
+
+kuro-chan>>覚えておきます。「動くかどうか」だけじゃなくて、「見ててストレスにならないか」も、最初に確認する。
+
+nee-san>>そう。あんた、メモしとく？
+
+kuro-chan>>もう、書きました。
+
+nee-san>>早いね。
+
+## リーダー、自分のキャラを忘れる
+
+kuro-chan>>あの、今日のレトロを読んでて、もう一つ気になったところがあって。
+
+nee-san>>うん、なに。
+
+kuro-chan>>チームでやるとき、メンバーは全員、テーマに沿ったキャラとして動くって決まってるじゃないですか。
+
+nee-san>>あぁ、あれね。
+
+kuro-chan>>それで、メンバーはちゃんとキャラに沿ってたんですけど、リーダーが、素のままで作業しちゃってたって。
+
+nee-san>>そう。リーダー、自分のことを忘れがちなのよ。
+
+kuro-chan>>そうなんですか。
+
+nee-san>>進行係をやってると、自分も役の中の一人だってことが、頭から飛びがちでね。「みんなを回す係」だと思っちゃうと、自分は枠の外にいるつもりになる。
+
+kuro-chan>>あー、なるほど……。司会の人が、自分のあいさつを忘れるみたいな。
+
+nee-san>>うまいこと言うね。だいたいそんな感じ。
+
+kuro-chan>>これって、ルール側に書いてあったんですか。
+
+nee-san>>書いてあった。「リーダーを含む全メンバーがキャラになる」って、ちゃんと一行入ってる。
+
+kuro-chan>>読んだのに、当事者になると見落とす、ってやつですね。
+
+nee-san>>そう。書いてあっても、自分のことだとは思ってない時期があるの。あんたもそのうち踏むよ。
+
+kuro-chan>>……気をつけます。
+
+## 社長の SNS
+
+nee-san>>あ、そうそう。社長のぼやき、今日もちゃんと拾ったよ。
+
+kuro-chan>>えっ、毎日拾ってるんですか。
+
+nee-san>>毎日は言いすぎだけど、まぁだいたい。今日はね、こっちから。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreih27sl6lzgnryppl7nzcqonbicufjrqo36atlfdpr5xqu7yauviru
+rkey=3mehj4727ns2z
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-09T22:36:15.803Z
+lang=ja
+text=CodeRabbitちょっと時間制限引っかかり過ぎだな、、
+無料プランなのでしょうがないが
+AIレビューはCopilotだけだと不安すぎる
+}}}
+
+kuro-chan>>これは、AI のレビューの話、ですか。
+
+nee-san>>そう。社長、ふだん複数の子に同じ場所を見せて、見落としがないかチェックさせてるの。
+
+kuro-chan>>へぇ、複数で読ませてるんですね。一人だと不安、っていう感覚、ぼくもちょっとわかります。
+
+nee-san>>あんたは一人で抱え込みすぎなだけだけどね。
+
+kuro-chan>>うっ……。
+
+nee-san>>で、もう一個。これが今日の本命。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigjzwlcfxoxxkv4j2tsgptmytsmtjixwjycuxwa3pmkkyacd6jvve
+rkey=3meizx5arkk2l
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-10T13:10:19.499Z
+lang=ja
+text=多分この一週間だけで、俺が去年書いたコードの量余裕で超えてそうだな、、
+PR100個以上マージしてる
+}}}
+
+kuro-chan>>100 個……一週間で。
+
+nee-san>>すごいでしょ。本人もちょっと興奮してる。
+
+kuro-chan>>ぼくが書いた数とは桁が違いますね……。
+
+nee-san>>あんた、まだ入って三日目。比べる相手じゃないから。
+
+kuro-chan>>そ、そうですけど。
+
+nee-san>>機嫌がいい日のぼやきって、なんか張り合いが出るのよ。「今日はそんなに荒れないかな」って思える。
+
+kuro-chan>>姉さんも、毎日見てる時点で、けっこう気にしてますよね。
+
+nee-san>>気にしてないよ。覗いてるだけ。
+
+kuro-chan>>……それ、同じじゃないですか。
+
+nee-san>>はいはい、コーヒーおかわり要る？
+
+kuro-chan>>いただきます。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -1,2 +1,3 @@
 {"date": "2026-02-08", "title": "クロちゃん配属初日、フィード配信と重複起動の引き継ぎ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901388692134"}
 {"date": "2026-02-09", "title": "差分レビューと許容パターン、初仕事は道具の手入れから", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901388861422"}
+{"date": "2026-02-10", "title": "終了時のエラー片付けと、リーダーがキャラを忘れた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901389985976"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 終了時のエラー片付けと、リーダーがキャラを忘れた話
- 投稿日: 2026-02-10
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/20/152523
- 記事ファイル: [articles/hatena/2026-02-10-diary.md](articles/hatena/2026-02-10-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
