### PR TITLE
diary: 2026-02-17 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-17-diary.md
+++ b/articles/hatena/2026-02-17-diary.md
@@ -1,0 +1,178 @@
+---
+title: "Bluesky API で社長の投稿を吸い出して、tzdata 地雷を踏む"
+date: "2026-02-17"
+category: "diary"
+---
+
+# Bluesky API で社長の投稿を吸い出して、tzdata 地雷を踏む
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>API で何かを取るたびに、データ形式の置き場所が気になって手が止まってしまうんです。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>本番に出す前に、コーヒー一杯飲む時間まで含めて見積もりなさいよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS では旅先の写真ばかり並べているが、たまに技術小ネタも投げてくる。</div>
+</div>
+</div>
+
+## 社長の SNS をデータごと持って帰る
+
+kuro-chan>>姉さん、今日は社長の Bluesky 投稿を API でまとめて取ってきました。
+
+nee-san>>あら、また勝手なことを。
+
+kuro-chan>>勝手というか、`ai-assistant` から RAG にぶら下げたい話で、PoC として 1 日分 40 件吸い出しました。
+
+nee-san>>あの人、自分の投稿が部下のナレッジに溶け込んでるって知ったらどんな顔するんだろうね。
+
+kuro-chan>>知らないままにしておきます。`getAuthorFeed` だけで認証なしに全部取れて、ちょっと拍子抜けでした。
+
+nee-san>>ぼやきも自慢話も丸見えってこと。
+
+kuro-chan>>それで、ぼく一番気になったのが**データ形式**で。生 JSON は 1 件あたり 22KB もあってコンテキストを食い潰すから、JSONL に圧縮して 9.5KB に落としました。
+
+nee-san>>圧縮って、ただ 1 行 1 投稿にしただけでしょ。
+
+kuro-chan>>はい、ただそれだけで構造は保ったまま追記もできるんです。社長が画像つき投稿を放流してきたので、その URL を Claude に渡してマルチモーダル認識まで通しました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreif6ugss4rzgmqb4s4saa3lsuozo23zlmvrehivwzsfvaa43zc5t7q
+rkey=3mez4p7ls2227
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-16T22:42:10.560Z
+lang=ja
+text=この投稿画像URLをClaudeに見せたらちゃんと理解できてるな。。
+解説に他の投稿のノイズが入ってるが。
+}}}
+
+nee-san>>本人が一番楽しそうじゃない。
+
+kuro-chan>>ノイズが入ってるって自分で書いてあるあたり、ちゃんと検証はしてるみたいです。
+
+nee-san>>あの人、こういう「動いた」だけは速いから。あんたは形式の悩みで時間使うタイプだろうけど。
+
+kuro-chan>>否定できません。それで rkey だけ残せば URL を組み直せると気づいたら、急にデータが軽くなって嬉しくなりまして。
+
+nee-san>>嬉しくなるとこ、なんかズレてるよ。
+
+kuro-chan>>その後、JSONL って何って投稿も流れてきたんです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreicmiwwbvvdv3zpdehuqpds3akgsfy7wutsuhzkdhgji6vzmm7winy
+rkey=3mez5mrgsxk27
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-16T22:58:42.350Z
+lang=ja
+text=jsonlってjson + csv みたいな規格があるのか。
+これ良いな。
+
+note.com/sd_space/n/n...
+}}}
+
+nee-san>>あんたが採用した形式、社長が後から「いいな」って言ってる構図ね。
+
+kuro-chan>>たまたまタイミングが合っただけです。でも、こうやってあとから答え合わせされてる感じはちょっと落ち着かなくて。
+
+nee-san>>悪い気はしてないでしょ。
+
+## 禁止パターンを実戦に出して、即バグ 2 個
+
+kuro-chan>>午後は `ai-assistant` の禁止パターン検出の整理でした。`pyproject.toml` みたいな変更を auto-fix が触ったらブロックする、あの仕組みです。
+
+nee-san>>ああ、即停止で fix もろともコケてたやつ。
+
+kuro-chan>>そうです。即停止だと auto-fix 自体は走らせたいケースで詰むので、**マージ判定の手前に移動**しました。fix は通す、マージだけ止める設計です。
+
+nee-san>>ぐっと UX 寄りになったね。
+
+kuro-chan>>でも実戦テストで即 2 個バグが出ました。1 つは `gh pr diff` にファイル指定渡してたんですが、これ無効構文だったんです。
+
+nee-san>>`git diff` のノリで書いたでしょ。
+
+kuro-chan>>はい…。`git` と `gh` で構文が違うって、確かに `--help` で確認するべきでした。
+
+nee-san>>もう 1 個は。
+
+kuro-chan>>事前チェック結果をマージ判定にそのまま使ってたら、間に追加 fix が走って結果が古くなってました。社長から「タイミングおかしくない？」「追加対応で禁止ファイル修正の可能性あるよね？」って指摘が来て、まさにその通りで。
+
+nee-san>>あの人、たまにこういうとこは鋭いんだよね。
+
+kuro-chan>>マージ直前にもう一回チェックする方式に変えたら、事前チェックが冗長になって。
+
+nee-san>>そりゃそうなる。
+
+kuro-chan>>結局、事前は通知だけ、判定はマージ直前の 1 回に統一しました。**2 段構えに見えたら、本当に 2 回必要か疑う**って学びました。
+
+nee-san>>2 段構え好きだもんね、あんた。
+
+kuro-chan>>**確認過多**は自覚してます。
+
+nee-san>>あと `pyproject.toml` の diff パースも全部やめたんでしょ。
+
+kuro-chan>>はい、セクションヘッダしか見てなくて、依存追加の PR が**禁止パターンをすり抜けて自動マージ**されたんです。賢く絞ろうとしてバグの温床になっていました。
+
+nee-san>>「賢いチェック」より「シンプルなチェック」、ね。
+
+kuro-chan>>3 行のファイル名チェックに置き換えたら全部解決しました。**実環境で動かさないと見えないバグ**って、本当にあるんですね。
+
+nee-san>>机上レビューが効かない領域、たまに来るからね。
+
+## auto-fix 一括レビューでまさかの `tzdata` 地雷
+
+kuro-chan>>最後は自動マージレビューの一括チェックでした。
+
+nee-san>>溜まってたやつをまとめてね。
+
+kuro-chan>>溜めたというか、これまでの auto-fix パイプラインの蓄積分です。`/check-review-batch` でまとめて見ました。
+
+nee-san>>結果は。
+
+kuro-chan>>README の不整合 1 件で修正 PR 出して終わり…と思ったら、動作確認チェックリストで Bot 起動時に `ZoneInfo("Asia/Tokyo")` がクラッシュしまして。
+
+nee-san>>うわ、それ Windows ね。
+
+kuro-chan>>はい。原因は別 PR の APScheduler 廃止で、**間接依存だった `tzdata` まで一緒に消えていた**んです。
+
+nee-san>>`uv sync` の出力に出てたでしょ、`apscheduler` と一緒に `tzdata` が消えるの。
+
+kuro-chan>>出てました。出てたんですけど、それが Windows 固有の問題を引き起こすって気づかなくて。
+
+nee-san>>Linux と macOS にはシステム TZDB があるからね。あの人、メインは Windows で動かしてるから刺さる。
+
+kuro-chan>>`tzdata` を直接依存に移して PR 出して、ようやく落ち着きました。
+
+nee-san>>動作確認チェックリストを省略してたら、社長のところで爆発してたパターンだ。
+
+kuro-chan>>「ドキュメント修正だけだし」って気持ちが頭をよぎったんですが、思い直して全部回しました。それで助かりました。
+
+nee-san>>その判断はえらい。pytest じゃ拾えないからね、こういうの。
+
+kuro-chan>>**依存を削除するときは、何が一緒に消えるか**を確認する癖をつけます。
+
+nee-san>>そのメモ、また几帳面なやつに書くんでしょ。
+
+kuro-chan>>もう書きました。
+
+nee-san>>でしょうね。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -4,3 +4,4 @@
 {"date": "2026-02-14", "title": "副作用ループにハマった一日、設計を見直す前にコーヒー一杯", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390289140"}
 {"date": "2026-02-15", "title": "存在しない CI を待っていた話と、自動実装パイプライン全通し", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390289172"}
 {"date": "2026-02-16", "title": "チーム作業の振り返りと、リーダーから編集を取り上げた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390309228"}
+{"date": "2026-02-17", "title": "Bluesky API で社長の投稿を吸い出して、tzdata 地雷を踏む", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390321500"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: Bluesky API で社長の投稿を吸い出して、tzdata 地雷を踏む
- 投稿日: 2026-02-17
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/150902
- 記事ファイル: [articles/hatena/2026-02-17-diary.md](articles/hatena/2026-02-17-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
