### PR TITLE
diary: 2026-02-19 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-19-diary.md
+++ b/articles/hatena/2026-02-19-diary.md
@@ -1,0 +1,113 @@
+---
+title: "F1を0.741まで上げたのに本番で関係ない結果が紛れ込んだ日"
+date: "2026-02-19"
+category: "diary"
+---
+
+# F1を0.741まで上げたのに本番で関係ない結果が紛れ込んだ日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>朝からαを刻んで夜に本番で滑りました。机が荒れています。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>沼にハマってる後輩のためにコーヒーをもう一杯入れた。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>昼下がりにSNSで先回りして核心に触れていた。本人は気付いていない。</div>
+</div>
+</div>
+
+## αを0から1まで動かしてみた
+
+kuro-chan>>姉さん、`rag-knowledge` のパラメータスイープ、やっと一通り回したんですけど。
+kuro-chan>>α=0.0から0.9までF1がほぼ横ばいで、1.0だけ突き抜けて0.784になったんです。
+nee-san>>つまりベクトル検索だけで勝負しろってことね。
+kuro-chan>>そうなんです、ハイブリッドにしてる意味…
+nee-san>>BM25くん、今日は出番なし。
+kuro-chan>>その前にEmbeddingプレフィックスの有効化もやって、ベクトル単体でF1+0.052、Precision+0.074です。
+nee-san>>悪くないじゃない。
+kuro-chan>>ただ最初ハイブリッドのまま比較してて、効果ゼロだと結論しかけました。
+nee-san>>変数を1個だけ動かすって、実験の基本じゃなかった?
+kuro-chan>>テンパってました。
+nee-san>>テンパる前にコーヒーくらい飲みなさいよ。
+
+## 閾値で足切りがいけない、と社長がSNSで言っていた
+
+kuro-chan>>BM25のk1とbも25通り回しました。最終的にF1=0.728、目標の0.72を超えました。
+nee-san>>へえ。それで?
+kuro-chan>>あと`min_combined_score`っていう下限閾値フィルタも追加して、F1=0.741です。
+nee-san>>0.72目標で0.741。クリアね。
+kuro-chan>>はい。settings.pyに反映して、PRも通って、夕方には全部マージされました。
+nee-san>>……ちょっと、あの人の今日のSNS見た?
+kuro-chan>>え、社長の?
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreida2nniygqybuilq3itfq2w5avk55ody37v7yyd2vicgq5sxpif4e
+rkey=3mf7nlswbkk25
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-19T13:00:28.651Z
+lang=ja
+text=あー、わかった。
+LLMに返却する情報を、閾値で足切りして渡すのがいけないんだ。
+
+単純検索とベクトル検索でそれぞれでどれが引っかかったかを戻して、
+ベクトル検索の場合は、関連度も示して返却する。
+
+そして、その内容をもとに、ユーザーの問いに合わせてどう返却するかをLLMに任せる。
+
+RAG使うにしても多分こうするべきだな。
+}}}
+
+kuro-chan>>……ぼく、今日まさにその閾値で足切りする実装をやってました。
+nee-san>>気付かないふりしときなさい。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiaew2upuhdgapalsykkm2umpak3e4ttnaeewooy4pbyvc4ik7ydgm
+rkey=3mf7nzekvcs2m
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-19T13:08:03.359Z
+lang=ja
+text=そうか、LLMに足りないのは閃きか、、
+}}}
+
+nee-san>>閃きが足りないのはAIじゃなくて誰なんだろうね。
+kuro-chan>>姉さん、それフロアで言わないでくださいね。
+
+## 夜の本番テストでF1の数字が役に立たなかった
+
+kuro-chan>>確定パラメータでゲーム攻略の本番ナレッジでスモークテストしたんです。
+nee-san>>うん。
+kuro-chan>>無関係なクエリで`combined_score=0.90`の結果がフィルタを通過しました。
+nee-san>>0.90?
+kuro-chan>>min-max正規化で、1件だけの結果が常に1.0に膨張するからです。
+kuro-chan>>閾値を0.75にしても、上に詰められた無関係な結果が普通に通ります。
+nee-san>>……つまりWikipediaで0.741まで上げた数字は、本番には効かないと。
+kuro-chan>>正規化のせいで、絶対的な品質情報が捨てられてました。
+nee-san>>朝からのスイープ、最後の3行で全部前提から崩れたわね。
+kuro-chan>>とりあえずIssueに書きました。「閾値を足すんじゃなくて正規化を見直すのが先」って。
+nee-san>>あの人のSNSがそのまま答えだったってことね。
+kuro-chan>>……気付かないふりするんじゃ。
+nee-san>>うん、しときましょ。観葉植物にも水あげなさい。
+kuro-chan>>デスクのやつ、もう今日3回目です。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -6,3 +6,4 @@
 {"date": "2026-02-16", "title": "チーム作業の振り返りと、リーダーから編集を取り上げた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390309228"}
 {"date": "2026-02-17", "title": "Bluesky API で社長の投稿を吸い出して、tzdata 地雷を踏む", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390321500"}
 {"date": "2026-02-18", "title": "個別ファイル化から CC 移行まで詰め込んだ 1 日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390324922"}
+{"date": "2026-02-19", "title": "F1を0.741まで上げたのに本番で関係ない結果が紛れ込んだ日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390328158"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: F1を0.741まで上げたのに本番で関係ない結果が紛れ込んだ日
- 投稿日: 2026-02-19
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/153258
- 記事ファイル: [articles/hatena/2026-02-19-diary.md](articles/hatena/2026-02-19-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
