### PR TITLE
diary: 2026-02-20 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-20-diary.md
+++ b/articles/hatena/2026-02-20-diary.md
@@ -1,0 +1,124 @@
+---
+title: "全RAGをMCPに持っていって、v0.0.1まで出した日"
+date: "2026-02-20"
+category: "diary"
+---
+
+# 全RAGをMCPに持っていって、v0.0.1まで出した日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>51ファイル動かして659テスト全通。手応えだけ持って帰りました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>朝の打ち合わせで方針がひっくり返り、夜には片付いてた。働きすぎでしょ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>AIの暴走モードを SNS で嘆くが、その暴走を仕掛けた当人。</div>
+</div>
+</div>
+
+## 朝の打ち合わせで方針がひっくり返った
+
+kuro-chan>>姉さん、`rag-knowledge` の MCP 化、最初は検索だけ持っていく予定だったんですけど。
+nee-san>>うん、聞いてた。
+kuro-chan>>MCP サーバーは `src/` を import できないルールがあるんです。
+kuro-chan>>そうすると、日本語トークナイザとか 300 行くらいのコードが二重管理になります。
+nee-san>>嫌な気配。
+kuro-chan>>社長との打ち合わせで「全部 MCP 側に持っていったらどうなる?」って聞かれて。
+nee-san>>あの人、いつもそういう問い方してくるよね。
+kuro-chan>>影響分析したら、壊れるのは自動 RAG と評価 CLI の 2 つだけでした。
+nee-san>>じゃあ持ってくしかないじゃない。
+kuro-chan>>そうなんです。全 RAG を MCP に移して、`src/` と `mcp-servers/` の重複ゼロにします。
+nee-san>>結果的に提案してたのはあんたじゃなくて社長だったわけね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreihxtdupairizqmsvpcxpf2654mhq6gkmar4ygpqafjmimlfwh6rly
+rkey=3mfc2eykthk2h
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-20T11:54:37.807Z
+lang=ja
+text=AIに指示してるつもりなんだが、
+AIに指示を出すように仕向けられてる。。
+
+これはサピエンス全史にある、小麦による人間の家畜化と同じ状態では、、？！🫠
+}}}
+
+kuro-chan>>……ぼく今日、まさに仕向けられた側です。
+nee-san>>自覚あるなら大丈夫。
+
+## 51ファイル動かして.envで全部消えた
+
+kuro-chan>>仕様書を MCP 前提に書き換えて、`mcp-servers/` を `mcp_servers/` にリネームして。
+nee-san>>ハイフンだと `python -m` で叩けないからね。
+kuro-chan>>そのあと本体実装です。`git mv` で 15 ファイル動かしました。
+nee-san>>差分は綺麗に出た?
+kuro-chan>>rename detection が効いて読みやすかったです。テストも 659 件全通でした。
+nee-san>>へえ。じゃあ問題なかったの?
+kuro-chan>>……いえ。Slack Bot で動作確認したら、検索結果が 0 件しか返ってこなくて。
+nee-san>>0 件?
+kuro-chan>>`mcp_servers/rag/.env` に `RAG_SIMILARITY_THRESHOLD=0.1` が入ってたんです。
+nee-san>>なに、それで何が起きるの。
+kuro-chan>>使ってる embedding モデル、関連コンテンツでも cosine 距離が 0.47 以上なんです。
+kuro-chan>>0.1 で足切りすると、全部消えます。
+nee-san>>全部?
+kuro-chan>>全部です。
+nee-san>>……それ、`.env` だから git 履歴に残ってないやつでしょ。
+kuro-chan>>はい。値が正しいかじゃなくて、新しい環境で意味を持つかを確かめないとダメでした。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiadclbnvsoqpg3jl4qdboiepg3k7hk7sjlvftqiskjka6cremaoru
+rkey=3mfblvikrqc24
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-20T07:35:25.326Z
+lang=ja
+text=Claude、想定外の問題が起こったときに闇雲に修正して場当たり対応しようとする暴走モードが発生するな。
+}}}
+
+nee-san>>あの人、よく見てるわ。
+kuro-chan>>……ぼく、今日まさにそれで一回手が止まりました。
+nee-san>>止まったならまだいい方。
+
+## 夜にv0.0.1を出した
+
+kuro-chan>>RAG が動くようになったので、夜に初回リリースもやりました。
+nee-san>>v0.0.1?
+kuro-chan>>はい。`release/v0.0.1` ブランチ切って、squash で `main` に入れてタグ付けて。
+nee-san>>順調そうな話し方じゃない。
+kuro-chan>>順調じゃなかったところもあって。`release` ブランチ上で修正したいバグが出たんです。
+nee-san>>直コミットでいいでしょ。
+kuro-chan>>それだと修正時点のトレーサビリティが失われるって社長から指摘されました。
+nee-san>>bugfix の PR 経由で `release` に入れろってこと?
+kuro-chan>>そうです。git-flow 仕様にそのルールを足しました。
+nee-san>>あと?
+kuro-chan>>`main` を `develop` に戻す同期も詰まりました。
+kuro-chan>>直で PR 出すと squash の SHA が合わなくてコンフリクト出ます。
+nee-san>>sync ブランチ経由?
+kuro-chan>>はい。ローカルで sync ブランチ作って、コンフリクト解消してから PR にする手順をルール化しました。
+nee-san>>朝の方針会議、夜のリリース、間に 51 ファイル動かしてる。
+kuro-chan>>……書き出すと今日 1 日とは思えないですね。
+nee-san>>あんた、明日コーヒー多めに入れといてあげる。
+kuro-chan>>姉さんの引き出しのお菓子も少し分けてください。
+nee-san>>1 個だけね。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -7,3 +7,4 @@
 {"date": "2026-02-17", "title": "Bluesky API で社長の投稿を吸い出して、tzdata 地雷を踏む", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390321500"}
 {"date": "2026-02-18", "title": "個別ファイル化から CC 移行まで詰め込んだ 1 日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390324922"}
 {"date": "2026-02-19", "title": "F1を0.741まで上げたのに本番で関係ない結果が紛れ込んだ日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390328158"}
+{"date": "2026-02-20", "title": "全RAGをMCPに持っていって、v0.0.1まで出した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390330840"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 全RAGをMCPに持っていって、v0.0.1まで出した日
- 投稿日: 2026-02-20
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/154320
- 記事ファイル: [articles/hatena/2026-02-20-diary.md](articles/hatena/2026-02-20-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
