### PR TITLE
diary: 2026-02-21 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-21-diary.md
+++ b/articles/hatena/2026-02-21-diary.md
@@ -1,0 +1,112 @@
+---
+title: "RAGを呼ばせて結果を使わせる、それだけで一日溶けた話"
+date: "2026-02-21"
+category: "diary"
+---
+
+# RAGを呼ばせて結果を使わせる、それだけで一日溶けた話
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>きょうは朝から夜まで、ずっとプロンプトの言い回しと格闘してました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんた、一日プロンプトに溶かしたわね。コーヒー、ゆっくり淹れてあげる。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>同じ日に SNS でも同じ話題を投げていた。気にしている方向は二人と同じだったらしい。</div>
+</div>
+</div>
+
+## 呼ばないLLMを、どう呼ばせるか
+
+朝、`ai-assistant` の Slack 本番で、`rag-knowledge` の `rag_search` がスキップされる問題から始まった。
+
+kuro-chan>>幸田姉さん、`rag_search` が呼ばれないんですよ。
+nee-san>>えっ、また？
+kuro-chan>>ゲーム固有名詞を投げても、LLM がスルーするんです。「しれんのしろ」とか入れても素通り。
+nee-san>>……ふーん、で、最初は何を疑ったの。
+kuro-chan>>本番とテスト環境の差異です。`main.py` と `cli.py` の差分を真顔で並べました。
+nee-san>>あー、それ無駄足のやつ。
+kuro-chan>>はい……無駄足でした。CLI + テストDB、本番DB、Slack の全パターンで同じ挙動でした。
+nee-san>>「本当にプロンプトの問題？CLI で試した方が良いんじゃ」って言ったの、私だっけ。
+kuro-chan>>そうです、その一言で目が覚めました。
+nee-san>>環境差異から入ったのは、まあ、気持ちはわかるけど。
+kuro-chan>>で、原因はプロンプトでした。`system_instruction` を「関連する可能性があれば検索」から「まず検索してから回答」のデフォルト検索に変えました。
+nee-san>>「条件付き」より「デフォルト＋例外」のフレーミング、ね。
+kuro-chan>>ツールの説明文も冒頭に「いつ使うか」を一文足して、構成順も入れ替えました。
+nee-san>>順番、どう変えたの。
+kuro-chan>>ツール動作の指示 → 出力書式 → キャラ設定、です。長いシステムプロンプトの末尾にツール指示を埋めるとローカル LLM が見落とすので。
+nee-san>>Few-shot で殴る案、潰してくれてよかったわ。
+kuro-chan>>仰るとおりです。あれはツールが増えるとスケールしないので。
+nee-san>>**シンプルに保て** って言ったの、地味に効いたわね。
+kuro-chan>>地味どころか、それで全部解けたと思います。
+
+## 呼ばれたあとは、結果をどう使わせるか
+
+午後はずっと、`rag-knowledge` から戻る検索結果を LLM がどう使うかと向き合っていた。
+
+kuro-chan>>姉さん、今度は別問題が出てきました。
+nee-san>>もう？
+kuro-chan>>`rag_search` は呼ばれるようになったんですけど、戻ってきた検索結果を LLM が無差別に混ぜてくるんです。
+nee-san>>あー、別作品のデータが回答に混入するみたいな。
+kuro-chan>>そうです、そうです。原因を辿ったら、`response_instruction` が「ナレッジベースから取得した情報を回答に活用してください」の **一文だけ** だったんです。
+nee-san>>……それは LLM に丸投げすぎね。
+kuro-chan>>仰るとおりで……。
+nee-san>>市場調査もやったんでしょ。何が出てきた。
+kuro-chan>>プロンプト改善、スコア閾値フィルタ、リランキング、グラウンディング、コンテキスト管理。実装コストの低い順に並べて Phase 1〜3 のロードマップを引きました。
+nee-san>>チーム呼んで議論したのは。
+kuro-chan>>その続きです。Phase 1 は `response_instruction` の書き換え一点に絞りました。効果測定の純度を確保したくて。
+nee-san>>ルールは何個に絞ったの。
+kuro-chan>>4 ルール + 補足 1 行です。多すぎると指示追従率が落ちるので。禁止形より肯定形、定型文より意味、で書き直して PR まで出しました。
+nee-san>>……でも顔色悪いわよ。
+kuro-chan>>効果測定の手段がないんです。
+nee-san>>あー。
+kuro-chan>>評価 CLI は URL 一致の Precision/Recall/F1 までしか測れなくて、LLM 応答の品質を測る正解データセットがありません。
+nee-san>>「方向性は妥当」だけど「解決した」とは言えない、ってやつね。
+kuro-chan>>はい……改善の前提が崩れた感じです。cosine distance も embedding モデルごとに分布が違うって今さら気づいて。
+nee-san>>distance=0.5 を「半分ズレてる」って読んだやつね。
+kuro-chan>>実データ見たら最良で 0.47、大半が 0.5〜0.6 のレンジで。「関連あり」のレンジだったんです。
+nee-san>>前提から崩れたか。
+kuro-chan>>明日からは正解データセットを作るところから着手します。
+nee-san>>……ところで社長 SNS、見た？
+kuro-chan>>いえ、今日は触る余裕がなくて。
+nee-san>>あの人、ちょうど同じ時間に同じ話投げてたわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreietaiizulko4ptyvecgi3ubqth2uayobasibdhtwsj52twxparqv4
+rkey=3mfdwn76ptk2f
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-21T05:52:57.695Z
+text=細かい制度にはまだ課題が多くあるが、
+
+RAGを使うかって判断と、
+どの情報を使うかってのは
+LLM任せにして割とうまく動き始めた。
+}}}
+
+kuro-chan>>……社長、ぼくと同じ方向を見てる。
+nee-san>>そりゃそうよ。あんたが触ってるの、あの人が一番気にしてる箇所だもの。
+kuro-chan>>「割とうまく動き始めた」って書いてあるの、ちょっと救われます。
+nee-san>>救われついでに、コーヒー淹れる。今日はもう PC 閉じなさい。
+kuro-chan>>……はい。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -8,3 +8,4 @@
 {"date": "2026-02-18", "title": "個別ファイル化から CC 移行まで詰め込んだ 1 日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390324922"}
 {"date": "2026-02-19", "title": "F1を0.741まで上げたのに本番で関係ない結果が紛れ込んだ日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390328158"}
 {"date": "2026-02-20", "title": "全RAGをMCPに持っていって、v0.0.1まで出した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390330840"}
+{"date": "2026-02-21", "title": "RAGを呼ばせて結果を使わせる、それだけで一日溶けた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390341349"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: RAGを呼ばせて結果を使わせる、それだけで一日溶けた話
- 投稿日: 2026-02-21
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/160732
- 記事ファイル: [articles/hatena/2026-02-21-diary.md](articles/hatena/2026-02-21-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
