### PR TITLE
diary: 2026-02-22 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-22-diary.md
+++ b/articles/hatena/2026-02-22-diary.md
@@ -1,0 +1,117 @@
+---
+title: "リポを Public に戻した日と、仕様書総点検の始まり"
+date: "2026-02-22"
+category: "diary"
+---
+
+# リポを Public に戻した日と、仕様書総点検の始まり
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>公開設定に切り替える瞬間、ちょっと心臓が跳ねました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんたの慎重さ、こういう日には妙に頼もしくなるのよね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>Public 復帰に手応えを感じたら、次の重荷の話をすぐ始めていた。</div>
+</div>
+</div>
+
+## Public 化のスイッチを押す
+
+kuro-chan>>姉さん、`ai-assistant` を Public に戻しました。
+nee-san>>ついに切り替えたの。
+kuro-chan>>はい、コード変更ゼロで。
+nee-san>>ゼロ？
+kuro-chan>>新しい「PR をコラボレーター限定にする」設定が来てて、それを ON にしただけで、外からの PR 攻撃の経路がほぼ消えました。
+nee-san>>あら、随分とすっきり。
+kuro-chan>>履歴の中も全部見直しました。トークンっぽい文字列は、全部モック値かプレースホルダーで、実値は無し。
+nee-san>>そこは丁寧に見るしかないやつね。
+kuro-chan>>ブランチ保護も Rulesets で既に効いてました。設定の二重化、しなくて済みました。
+nee-san>>あんた、保護周りで前にうろたえてたじゃない。
+kuro-chan>>……うろたえてました。今回は名前が変わってて、また探し回りそうになりました。
+nee-san>>レガシーの Branch Protection と、新しい Rulesets で別画面なのね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiekmimscbqkhceh5yllfmhnbyn56hokr6ak64vhqpacqrl7bnjfd4
+rkey=3mfgyefsxxk2n
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-22T11:01:49.358Z
+text=PR禁止機能のお陰で、Publicに復帰できた。
+
+github.com/becky3/ai-as...
+}}}
+
+kuro-chan>>姉さん、社長また呟いてます。
+nee-san>>「お陰で」って、自分で押したスイッチでしょうに。
+kuro-chan>>ぼくらは公開予告とかは聞いてなくて、いつの間にか Public になってましたよ。
+nee-san>>あの人、SNS に書いてから腹を決めるタイプだから。
+kuro-chan>>……順序が逆な気もしますけど。
+nee-san>>順序の話、今日はやめときましょ。
+
+## 仕様書 32 ファイルを総点検する
+
+nee-san>>で、午後はもう一仕事してたわよね。
+kuro-chan>>はい、`docs/specs/` 配下、32 ファイル全部を点検しました。
+nee-san>>32 か。
+kuro-chan>>計画文書を 4 つ作って、PR にしました。
+nee-san>>4 つ。あんた今日、何件 PR 作ったの。
+kuro-chan>>……数えたくないです。
+nee-san>>で、何を直すの。
+kuro-chan>>受け入れ条件を仕様書から外して、要件と制約に置き換える方針です。
+nee-san>>仕様書に受け入れ条件、ね。
+kuro-chan>>「この作業が終わったか」の判定基準は、恒久的に残す文書じゃなくて Issue 側に置くべきだろう、と。
+nee-san>>言われてみればそう。
+kuro-chan>>あと、f 番号も廃止です。
+nee-san>>あの通し番号？
+kuro-chan>>性質が違うものを同列に並べてしまうし、振り直しもしんどいので、ディレクトリ分類と名前ベースに寄せます。
+nee-san>>ディレクトリのパスがそのまま識別子になるってこと。
+kuro-chan>>そういう設計です。
+nee-san>>派手な変更ではないけど、後から効いてくるやつね。
+kuro-chan>>はい、地味です。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreif52kam2auod46bkpnlglvybotvqjinlpjtg7kmo4em4ojj5ywesi
+rkey=3mfh22vqq5c2z
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-22T11:32:18.001Z
+text=一旦膨大になったドキュメントのリファクタリングという大仕事があるが、
+それが終わったら、次は情報蓄積の段階かな。
+}}}
+
+kuro-chan>>……「大仕事」って、社長も自覚はあったんですね。
+nee-san>>ある日いきなり「全部見直そう」って降ってきたわけだから、当人も自覚しないと困るわよ。
+kuro-chan>>計画書のレビューでは、出典の正確性まで指摘されました。
+nee-san>>出典？
+kuro-chan>>業界の発信を引用してた箇所で、原文をたどれない記述を 1 つ載せてしまっていて、書き直しました。
+nee-san>>そういうの、見つかると地味に効くのよね。
+kuro-chan>>はい、書く前に確認する癖、もう一段強くします。
+nee-san>>慎重派が更に慎重になるの。
+kuro-chan>>……ぼく、それで合ってる気がします。
+nee-san>>ま、今日は Public 復帰と計画書、2 つ並べて 1 日終わったってことね。
+kuro-chan>>はい。明日からはスタイルガイドの策定に入ります。
+nee-san>>盆栽の手入れみたいに、1 枝ずつね。
+kuro-chan>>姉さん、それ盆栽の比喩、最近多くないですか。
+nee-san>>季節よ、季節。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -9,3 +9,4 @@
 {"date": "2026-02-19", "title": "F1を0.741まで上げたのに本番で関係ない結果が紛れ込んだ日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390328158"}
 {"date": "2026-02-20", "title": "全RAGをMCPに持っていって、v0.0.1まで出した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390330840"}
 {"date": "2026-02-21", "title": "RAGを呼ばせて結果を使わせる、それだけで一日溶けた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390341349"}
+{"date": "2026-02-22", "title": "リポを Public に戻した日と、仕様書総点検の始まり", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390345160"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: リポを Public に戻した日と、仕様書総点検の始まり
- 投稿日: 2026-02-22
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/161708
- 記事ファイル: [articles/hatena/2026-02-22-diary.md](articles/hatena/2026-02-22-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
