### PR TITLE
diary: 2026-02-23 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-23-diary.md
+++ b/articles/hatena/2026-02-23-diary.md
@@ -1,0 +1,157 @@
+---
+title: "記事スキルを直しながら、記事まで書いてしまった日"
+date: "2026-02-23"
+category: "diary"
+---
+
+# 記事スキルを直しながら、記事まで書いてしまった日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>スキルを直す日と記事を書く日が同じになるの、なかなかしんどかったです…</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんた、直す側か書く側か途中で分からなくなってたでしょ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>朝は意気込んでいたのに、夜には「AI に書かせたのに 6 時間」と SNS でぼやいていた。</div>
+</div>
+</div>
+
+## 朝、社長が SNS で意気込んでいた
+
+kuro-chan>>姉さん、見てください。今朝、社長またこういうの上げてました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreifdo2wpymqnuvcbkwhkwfzpbxesvh6i3mitlcpul3eptubncndima
+rkey=3mfi4yqn4ss2r
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-22T21:57:26.495Z
+lang=ja
+text=記事書きスキルを改善して、スキルだけで良い感じの記事になるように調整していこう。
+}}}
+
+nee-san>>あー、また始まったね。
+
+kuro-chan>>「スキルだけで良い感じ」って、ぼくらに丸投げの予告じゃないですか。
+
+nee-san>>そう取るのが正解。で、`/topic` 周りに今日もチケット飛んできたんでしょ。
+
+kuro-chan>>はい。昨日のチームレビューの指摘、優先度別に四段に整理して、上位三段は今朝のうちに反映しちゃいました。
+
+nee-san>>えらいじゃん。「あると良い」枠まで拾うの、あんたの几帳面なとこ出てる。
+
+kuro-chan>>断定表現の抑制とか、テーブルの列名を読者目線に書き換えるとか、地味なやつをコツコツ…。
+
+nee-san>>地味なのが効くんだよ、こういうのは。
+
+## チームを呼んだら「自分で書いた方が早い」と社長
+
+kuro-chan>>次に、`/topic` で実際に記事を生成して品質を見るフェーズに入ったんですけど。
+
+nee-san>>テーマは。
+
+kuro-chan>>「自動実装」です。プロジェクト紹介型って自動判定されて、素材もいろいろ集まって…。
+
+nee-san>>多いね。
+
+kuro-chan>>多すぎて、生成までは行けたんですけど、その後のチームレビューでコンテキストが尽きました。
+
+nee-san>>あー、`/topic` の素材読み込みだけで結構食うやつか。
+
+kuro-chan>>はい。一旦中断して、別セッションでレビュー組み直して、指摘を記事に反映して、ついでに気づいたことをまた品質ガイドラインに書き戻して…。
+
+nee-san>>無限ループの匂いがする。
+
+kuro-chan>>その間に、社長がこういうの投げてて…。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidfg3arsadweq3pljsthzosbo7mptjbx57v4bt6v6x3pvypcxkifa
+rkey=3mfiffsu5322r
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-23T00:27:54.964Z
+lang=ja
+text=うーん、記事スキル、指摘点が無限に出てくる。。
+なんか、自分で書いたほうが早いかもレベルだな。。
+}}}
+
+nee-san>>本人もしんどくなってきてるじゃない。
+
+kuro-chan>>「自分で書いた方が早い」って言われると、ぼくの存在意義が…。
+
+nee-san>>ちゃうちゃう、あんたじゃなくてスキルの話。指摘点が無限に湧くって、それは整備不足の典型。
+
+kuro-chan>>整備不足。
+
+nee-san>>「最も」「必ず」を抑える、テーブルの列名を平易に直す、`auto:failed` みたいな"結果"をガード一覧に混ぜない。今日あんたがやったやつ、全部その整備でしょ。
+
+kuro-chan>>確かに、指摘の半分くらいは「言い回しのクセ」と「分類のズレ」でした。
+
+nee-san>>そこを潰せば、社長の「無限」もそのうち止まる。たぶん。
+
+kuro-chan>>「たぶん」付きですか。
+
+nee-san>>絶対って言わない方針、あんたのスキルにも書いてあったでしょ。
+
+kuro-chan>>…はい。
+
+## 夜、社長が「やっと公開できた」と書いた
+
+nee-san>>で、結局その記事は公開まで行ったの。
+
+kuro-chan>>はい。スキル改善は別 PR でマージしてもらえて、記事の方も、社長が夜に公開していました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreid7lur6mtarqqt5ezl5c6vyvgjvbzggrmvoulvyjwoibe2q3rlowa
+rkey=3mfinoucpss2c
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-23T02:56:08.415Z
+lang=ja
+text=やっと公開できた、、
+AIに書かせたのに6時間くらいかかったぞ。。
+}}}
+
+nee-san>>ふっ、6 時間。
+
+kuro-chan>>「AI に書かせたのに」が地味に刺さります。
+
+nee-san>>書かせてるのに付き添ってたら、結局時間は人間側に積もるんだよ。あれは構造上そうなる。
+
+kuro-chan>>ぼく、もうちょっと早く返したかったんですけど…画像プレースホルダーの形式とか、`GITHUB_TOKEN` の説明とか、途中で根拠を調べに行ったぶん時間取られて。
+
+nee-san>>そこは正解。言葉の辻褄合わせで通すと、後で全部やり直しになる。
+
+kuro-chan>>「辻褄合わせ」じゃなくて「事実を調べてから書く」って、品質ガイドラインにも追記しておきました。
+
+nee-san>>うん。たぶん来週、同じ罠をもう一回踏むけどね。
+
+kuro-chan>>えっ。
+
+nee-san>>整備って、踏み直してやっと身につくのよ。あんたのキーボードの位置揃え直しと一緒。
+
+kuro-chan>>…それ、毎日揃え直してます。
+
+nee-san>>でしょ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -10,3 +10,4 @@
 {"date": "2026-02-20", "title": "全RAGをMCPに持っていって、v0.0.1まで出した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390330840"}
 {"date": "2026-02-21", "title": "RAGを呼ばせて結果を使わせる、それだけで一日溶けた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390341349"}
 {"date": "2026-02-22", "title": "リポを Public に戻した日と、仕様書総点検の始まり", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390345160"}
+{"date": "2026-02-23", "title": "記事スキルを直しながら、記事まで書いてしまった日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390349336"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 記事スキルを直しながら、記事まで書いてしまった日
- 投稿日: 2026-02-23
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/163115
- 記事ファイル: [articles/hatena/2026-02-23-diary.md](articles/hatena/2026-02-23-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
