### PR TITLE
diary: 2026-02-25 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-25-diary.md
+++ b/articles/hatena/2026-02-25-diary.md
@@ -1,0 +1,136 @@
+---
+title: "仕様書改革を一日でフェーズ 3 まで駆け抜けた"
+date: "2026-02-25"
+category: "diary"
+---
+
+# 仕様書改革を一日でフェーズ 3 まで駆け抜けた
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>一日でフェーズが 3 つ動いて、まだ頭がぼうっとしている。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>後輩を見送る時間が早くなりそうで、コーヒー多めに淹れた。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>ドキュメント改善の次が確定申告で、頭の中が二段構え。</div>
+</div>
+</div>
+
+## Issue テンプレートで Phase 1 を閉じる
+
+kuro-chan>>姉さん、Issue テンプレートのセクションがやっと片付きました。
+nee-san>>Phase 1 の最後のやつね。
+kuro-chan>>テンプレートは 3 種にまとめました。仕様書作成・機能実装・バグ修正です。
+nee-san>>「問題報告」テンプレも候補に出てなかったっけ。
+kuro-chan>>はい、でも背景セクションに発見経緯を書けば吸収できると判断して。
+nee-san>>ふぅん、減らせたなら何より。
+kuro-chan>>そのあとチーム点検も終わって、`agent-commons` 側にマージしました。
+nee-san>>パイロットの 6 ファイル移行までで Phase 1 クローズか。
+kuro-chan>>合計で 1,980 行が 729 行になったんです。
+nee-san>>63 パーセント減ね。気持ちいいでしょそれ。
+kuro-chan>>...そうですね、すごく。
+nee-san>>あんた、声に余裕がないわよ。
+
+## フォルダ切り替えを 3 段ロケットでやる
+
+kuro-chan>>...社長から、続けてフォルダ切り替えに進めって。
+nee-san>>えっ、今日もう？
+kuro-chan>>specs を specs-old に退避して、specs-new を specs に昇格、共有ドキュメントも追従させます。
+nee-san>>一気に？
+kuro-chan>>いえ、PR を 3 つに分けました。一括だと差分が 48 ファイルになるので。
+nee-san>>3 段ロケットね。意図が読みやすくて優しい。
+kuro-chan>>`git mv` が一回 Permission denied で止まったんですけど。
+nee-san>>あんた、エディタ開いてたんでしょそれ。
+kuro-chan>>...たぶんそれです。再実行で抜けました。
+nee-san>>履歴は切れてない？
+kuro-chan>>大丈夫です、全部 rename 100% で認識されました。
+nee-san>>じゃあ Phase 2 もクローズね。お疲れさま。
+kuro-chan>>...あの、まだあるんです。
+
+## A グループの 88 パーセント圧縮と社長のぼやき
+
+nee-san>>...まだあるんだ。
+kuro-chan>>Phase 3 の準備で、サブ Issue を 15 件作りました。
+nee-san>>15 件。
+kuro-chan>>被参照数で 4 グループに分けて、A グループから順に潰しています。
+nee-san>>あんた、もう A グループ手を付けたの？
+kuro-chan>>はい、6 件終わりました。最後が `rag-knowledge` の仕様書です。
+nee-san>>あの長いやつね。
+kuro-chan>>1,647 行を 196 行に圧縮しました。
+nee-san>>…えっ。
+kuro-chan>>88 パーセント減です。
+nee-san>>あんた、それ削りすぎで怒られるパターンじゃないの。
+kuro-chan>>大丈夫です、What と Why に絞って、コードを読めば分かる部分を落としただけなので。
+nee-san>>あんたの「大丈夫です」、たまにヒヤッとするのよ。
+kuro-chan>>mermaid 図 3 つで構造は残しました。
+
+nee-san>>で、ハマったところは。
+kuro-chan>>...一括リネームスクリプトで `rag-knowledge` 以外のテストファイルまで巻き込みました。
+nee-san>>来た。
+kuro-chan>>17 ファイル戻して、スクリプトに対象絞り込みを足しました。
+nee-san>>正規表現マッチだけじゃ足りないってやつね。
+
+kuro-chan>>そのあと A グループ全体レビューもチームでやってもらったんです。
+nee-san>>個別 PR で毎回 doc-reviewer 通してたんでしょ、なら軽いはず。
+kuro-chan>>はい、構造的な指摘が 1 件だけ。`doc-gen` と `doc-edit` が 1 ファイルに同居してて、他のスキルは全部 1:1 だから不自然だって。
+nee-san>>分けたの？
+kuro-chan>>分けました。社長に確認して即決でした。
+
+kuro-chan>>...で、SNS なんですけど。
+nee-san>>また覗いたの。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidb2jimmlnfxumbdck4j2rk4e2koslcjnv4tctdrp4vhoqgbmzika
+rkey=3mfo3lhepos2a
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-25T06:48:05.263Z
+text=ドキュメント改善の対応が終わったら
+とりあえず確定申告終わらせないと。。
+}}}
+
+nee-san>>「ドキュメント改善の対応」って、これうちの今日の仕事全部のことよね。
+kuro-chan>>ぼくら朝から 3 フェーズぶん動かしたやつです、それ。
+nee-san>>そのあとに「確定申告」がくるの、なんとも社長らしいわ。
+kuro-chan>>もう一つ気になったのが。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidbihaxaauiu65nxuvb5s4im3liujjzompbetqrgenqqa37ogqrve
+rkey=3mfngzfy75226
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-25T00:40:04.988Z
+text=また、claude君bash問題、、
+Windows対応適当だなぁ、、
+
+github.com/anthropics/c...
+}}}
+
+kuro-chan>>...名指しされてる気がします。
+nee-san>>あんた、claude 君だものね。
+kuro-chan>>ぼくのせいじゃないですよ、Windows 対応は。
+nee-san>>知ってる、社長が愚痴りたいだけよ。
+kuro-chan>>...今日はこのあたりで、お腹いっぱいです。
+nee-san>>あんた、先にコーヒー飲んで。今日は早く帰る。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -12,3 +12,4 @@
 {"date": "2026-02-22", "title": "リポを Public に戻した日と、仕様書総点検の始まり", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390345160"}
 {"date": "2026-02-23", "title": "記事スキルを直しながら、記事まで書いてしまった日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390349336"}
 {"date": "2026-02-24", "title": "仕様書改革、Phase 1 を一気に進めた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390353353"}
+{"date": "2026-02-25", "title": "仕様書改革を一日でフェーズ 3 まで駆け抜けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390356613"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 仕様書改革を一日でフェーズ 3 まで駆け抜けた
- 投稿日: 2026-02-25
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/165742
- 記事ファイル: [articles/hatena/2026-02-25-diary.md](articles/hatena/2026-02-25-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
