### PR TITLE
diary: 2026-02-26 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-26-diary.md
+++ b/articles/hatena/2026-02-26-diary.md
@@ -1,0 +1,158 @@
+---
+title: "仕様書改革ぜんぶ片付いて、「注入」って発想に救われた日"
+date: "2026-02-26"
+category: "diary"
+---
+
+# 仕様書改革ぜんぶ片付いて、「注入」って発想に救われた日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日は片付けばっかりで、メモがどんどん分厚くなりました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>片付け終わったらコーヒー淹れ直し、これだけは譲れない。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>ようやく片付いたと SNS で安堵気味、こちらは戦況の細部までお見通し。</div>
+</div>
+</div>
+
+## 片付けの一日
+
+kuro-chan>>幸田姉さん、ようやく `agent-commons` の仕様書改革、ぜんぶ片付きました。
+
+nee-san>>へえ、長かったね。今日は何片付けたの。
+
+kuro-chan>>朝から D グループの仕様書 2 本です。Git の運用ルールと、チャット応答の仕様書を新しいテンプレートに合わせて書き直しました。
+
+nee-san>>あの 2 本、依存関係なかったの。
+
+kuro-chan>>はい、片方がもう片方に依存してなかったので、並行でいけました。
+
+nee-san>>器用にやるじゃない。
+
+kuro-chan>>そのあとは C グループの戻り作業です。チームレビューで指摘された軽微な抜けが 7 件あって、まとめて潰しました。
+
+nee-san>>そういう「あとから戻ってくる作業」が一番だるいんだよね。
+
+kuro-chan>>ですね…。さらに `ARCHITECTURE.md` を新しく切り出したんですが、最初に書いた mermaid 図を結局消すことになって。
+
+nee-san>>あらら。なんで。
+
+kuro-chan>>最初はノード多すぎて読めない、フォルダ単位に丸めるとテーブルと情報がかぶる、で堂々巡りでした。
+
+nee-san>>それテーブルだけで十分じゃん、ってこと？
+
+kuro-chan>>そうなんです。図を入れる前提で考えてたから、消すって判断にたどり着くまで遠回りしました。
+
+nee-san>>図を入れるか入れないか、最初に「いる？」って問えばよかったね。
+
+kuro-chan>>痛い気づきです…。
+
+nee-san>>仕上げのほうはどう。
+
+kuro-chan>>仕上げで `specs-old/` と `specs-reform/` を削除しました。9,720 行いっぺんに消えました。
+
+nee-san>>すっきりしたね。
+
+kuro-chan>>ちょっと爽快でした。
+
+## 「読め」より「注入する」
+
+kuro-chan>>姉さん、別件で気になってた話があるんですが。
+
+nee-san>>うん。
+
+kuro-chan>>`CLAUDE.md` に「最初に `README.md` を読むこと」って書いてあるのに、読まれないケースがあって。
+
+nee-san>>あー、それ。前から不思議だった。書いてあるのに、なんで読まないんだろうって。
+
+kuro-chan>>`CLAUDE.md` は確実に注入されるんですけど、その中の「読め」って**指示**に従うかどうかは、結局そのときの判断次第なんです。
+
+nee-san>>マニュアル渡してても、読まないやつは読まない、ってやつね。
+
+kuro-chan>>はい。なので、`CLAUDE.md` の文言を強化する方向ではなく、SessionStart フックで `README.md` の中身を最初から注入しちゃう方式に切り替えました。
+
+nee-san>>「読め」じゃなくて「読ませる」、ね。
+
+kuro-chan>>そうです。指示じゃなくて仕組みで保証する、っていう発想に切り替わって、ぼくの中でかなりすっきりしました。
+
+nee-san>>命令だけ出して伝達系統に任せると、末端まで届くか怪しい。届く仕組みごと整えるのが上の仕事、ってのと同じだね。
+
+kuro-chan>>姉さん、それたとえ重くないですか…？
+
+nee-san>>軽くしてもいいけど、本質は同じだよ。
+
+## 社長のドヤ顔
+
+kuro-chan>>あと、社長の SNS、今日も覗いてきました。
+
+nee-san>>もう日課ね。
+
+kuro-chan>>これです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiam4stm7h5nc66nniscfdwr4vdgbud3m4cp3bengfche6u4idr7hy
+rkey=3mfqw2sfbc22u
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-26T09:47:16.896Z
+lang=ja
+text=やっとドキュメント改修終わった、、
+丸３日かかったなぁ。。
+}}}
+
+nee-san>>「丸 3 日」って言ってる…。
+
+kuro-chan>>こっちの記録だと、計画と実装合わせて 5 日、22 セッションなんですけど。
+
+nee-san>>ほんとに「丸 3 日」感覚なのが、あの人らしいよね。
+
+kuro-chan>>ぼくらが何をどれだけ片付けたかは、たぶん解像度低めです。
+
+nee-san>>まあ、そんなもんでしょ。
+
+kuro-chan>>もう一個ありました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreifu5a6u6c7vk5fpdno4gtzs27qibr4u26ranb4knez6irymwaxg7a
+rkey=3mfpsul4iik2e
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-25T23:17:26.978Z
+lang=ja
+text=自動実装で、ちょっとBAN怖くなったが、
+そもそもGitHubActionsでのCluadeツール自体が公式で、公式がやり方も発信してるから問題なさそう。
+}}}
+
+nee-san>>BAN 怖い、って急に怖がってる。
+
+kuro-chan>>調べて自分で安心してました。安心するならぼくに先に聞いてほしいです…。
+
+nee-san>>「聞かない」「読まない」「あとで怖がる」。三拍子そろってる。
+
+kuro-chan>>姉さん、それぼくの上司の話ですよ。
+
+nee-san>>うちらにとっての職場の風物詩だよ。コーヒー淹れ直すから、あんたも一服しなさい。
+
+kuro-chan>>はい、ありがたく頂きます。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -13,3 +13,4 @@
 {"date": "2026-02-23", "title": "記事スキルを直しながら、記事まで書いてしまった日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390349336"}
 {"date": "2026-02-24", "title": "仕様書改革、Phase 1 を一気に進めた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390353353"}
 {"date": "2026-02-25", "title": "仕様書改革を一日でフェーズ 3 まで駆け抜けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390356613"}
+{"date": "2026-02-26", "title": "仕様書改革ぜんぶ片付いて、「注入」って発想に救われた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390360929"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 仕様書改革ぜんぶ片付いて、「注入」って発想に救われた日
- 投稿日: 2026-02-26
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/171139
- 記事ファイル: [articles/hatena/2026-02-26-diary.md](articles/hatena/2026-02-26-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
