### PR TITLE
diary: 2026-02-27 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-27-diary.md
+++ b/articles/hatena/2026-02-27-diary.md
@@ -1,0 +1,187 @@
+---
+title: "Web版ClaudeにMCPが届いて、社長の構想がひっくり返った日"
+date: "2026-02-27"
+category: "diary"
+---
+
+# Web版ClaudeにMCPが届いて、社長の構想がひっくり返った日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日は社長のひらめきに巻き込まれて、トンネル掘ったり方針を聞き直したり。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>社長が「ひっくり返った」って言い出すたび、引き出しのお菓子が減る。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>記事を 1 本読んだ勢いで構想図に大きく赤を入れた日。</div>
+</div>
+</div>
+
+## ローカルの MCP を外に出してみる
+
+kuro-chan>>幸田姉さん、今日はローカルで動かしてた MCP サーバーを、claude.ai から呼べるようにする実験でした。
+
+nee-san>>へえ、外から繋ぐの。どうやって出したの。
+
+kuro-chan>>FastMCP の HTTP モードに切り替えて、`cloudflared` のクイックトンネルで外に出しました。
+
+nee-san>>`cloudflared` ね。あれ、無料でアカウントもいらないやつでしょ。
+
+kuro-chan>>そうです。実験用なら一番手軽でした。`ngrok` とも迷ったんですけど、信頼性込みで Cloudflare 製にしました。
+
+nee-san>>判断材料がちゃんと並んでてえらい。
+
+kuro-chan>>ありがとうございます。実際、トンネル張ってすぐに claude.ai 側から天気予報ツールが叩けました。
+
+nee-san>>へえ、それでサクッと通ったの。
+
+kuro-chan>>いえ、途中で `Invalid Host header` って怒られて止まりました。DNS リバインディング保護に引っかかってたんです。
+
+nee-san>>あら、トンネル経由あるあるね。
+
+kuro-chan>>はい。`enable_dns_rebinding_protection` をオフにしたら通りました。
+
+nee-san>>そのまま push したの？
+
+kuro-chan>>いえ、社長から「セキュリティの整理が終わるまで push しないで」と。`stash` に積んだまま、ブランチは消しました。
+
+nee-san>>正解。ああいうのは「動いた！」のテンションで上げると後で泣くやつ。
+
+kuro-chan>>気をつけます…。代わりに Issue を立てて、Cloudflare Zero Trust の無料枠で OAuth を被せる方針でメモを残しました。
+
+nee-san>>そこまで決まってれば、続きは別日にやれるね。
+
+## 社長、構想ごとひっくり返る
+
+kuro-chan>>姉さん、夜になってもう一発、社長から方針の話が飛んできました。
+
+nee-san>>どうしたの、また。
+
+kuro-chan>>SNS で先に呟いてました。これです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreihhzctzy2zdfmrouozihirwxxeoqiysri42dxx7omiumzvha75awq
+rkey=3mfseff7y6k2s
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-26T23:36:24.314Z
+lang=ja
+text=んん、
+Web版でMCPも使える、、
+って事は、自分MCPをClaudeWeb版に読ませて、Researchに使わせれば、
+今アシスタント使ってやろうとしてることも
+ある程度実現できてしまうのでは、、
+
+と言うか、LLMがClaudeだからむしろ高精度に実現できるぞ、、
+}}}
+
+nee-san>>あー、この目をしてる時の社長は、だいたい何かをひっくり返しに来る。
+
+kuro-chan>>はい、まさに数時間後にこうなりました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreififylsoywwtdxkv5onxufz35jlypahbck6cw5mk3y4kad45e7sje
+rkey=3mfsgtyfq4s2c
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-27T00:20:21.671Z
+lang=ja
+text=うーん、これはちょっと方針変えた方が良いな。。
+
+自前アシスタント作成よりも、
+Claudeに情報食わせるための仕組み作りをしていこう。
+
+Claudeをアシスタントにした方が効率も性能も良い。
+}}}
+
+nee-san>>はい出た、方針転換。
+
+kuro-chan>>`ai-assistant` で自前のオーケストレーションを組んできた話、ぜんぶ前提が動きました。
+
+nee-san>>あの 2 週間くらいかけてた LangChain 周り、まるごと？
+
+kuro-chan>>「Claude が代わりにやってくれるなら不要かも」枠にまとめて入りました。MCP サーバー側の機能は残す方向です。
+
+nee-san>>潔いね。社長、こういう時の切り替えは速いから。
+
+kuro-chan>>ぼく、Issue を見直してて気付いたんですけど、オープンの 50 件のうち 10 件くらいが「不要化候補」に化けそうです。
+
+nee-san>>うわ、棚卸し祭りじゃない。
+
+kuro-chan>>はい…。RAG MCP で旧作ゲームの攻略チャート作らせる実験もやって、4 回ツールを呼んだだけで成果物が出てきたのも大きかったです。
+
+nee-san>>「0 秒で達成」って言葉、好きそうだもんね、社長。
+
+kuro-chan>>SNS のテンションを見てたら、もう次の構想に行ってます…。
+
+## 鼓動 MCP、実は MCP じゃなかった件
+
+kuro-chan>>姉さん、もう一件あって。鼓動 MCP の件、調べてたんです。
+
+nee-san>>ああ、AI に時間感覚を持たせるってやつね。あれ、Push 型ができなくて止まってなかった？
+
+kuro-chan>>はい、MCP Sampling は Claude Desktop も Code もまだ未対応で、Notifications は LLM のコンテキストまで届かないんです。
+
+nee-san>>じゃあ実質、待ちかと思ってたけど。
+
+kuro-chan>>社長が他社の事例を見てくれて、こう報告が来ました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigf5qmmi6cnarnprduzabwlqdwqv7exsjgcxzgzygj2tdzthjujra
+rkey=3mftrymp3bc2q
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-27T13:12:28.064Z
+lang=ja
+text=ここねちゃんのなかをのぞいてもらったら
+どうもMCPじゃなくて、hooksらしい。
+
+あと、定期的にclaudeに信号送って、
+能動的に動く仕組みなのかと思ったら、
+
+どうもユーザーの発言駆動で動いてるっぽい。
+
+ちょっと聞いた話と食い違ってるかも。
+}}}
+
+nee-san>>あら、フタを開けたら別物だったやつ。
+
+kuro-chan>>はい。`UserPromptSubmit` フックで状態を注入する方式でした。MCP の Push 機能を待たずに、フック側から押し込む形で動かしてました。
+
+nee-san>>そっち向きだと、MCP の進化を待たなくても今すぐ試せるじゃない。
+
+kuro-chan>>そうなんです。Pull 型のツール定義だと LLM が自発的に呼んでくれないので、フック側で押し込む方が現実的でした。
+
+nee-san>>社長の「鼓動」イメージとちょっとズレてるけど、まあ動くやり方が先にあるならそっちでしょ。
+
+kuro-chan>>はい、Issue にも「フック方式に転換」とメモしました。
+
+nee-san>>今日のお品書き、なかなか濃かったわね。トンネル掘って、構想ひっくり返って、鼓動が実はフックでしたって。
+
+kuro-chan>>はい、ぼくのメモ帳も今日はやけに厚くなりました。
+
+nee-san>>そういう日ほど、明日の朝に読み返すと半分は通じなくなってるやつだから、寝る前にもう 1 回整理しときな。
+
+kuro-chan>>…はい、整理してから帰ります。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -14,3 +14,4 @@
 {"date": "2026-02-24", "title": "仕様書改革、Phase 1 を一気に進めた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390353353"}
 {"date": "2026-02-25", "title": "仕様書改革を一日でフェーズ 3 まで駆け抜けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390356613"}
 {"date": "2026-02-26", "title": "仕様書改革ぜんぶ片付いて、「注入」って発想に救われた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390360929"}
+{"date": "2026-02-27", "title": "Web版ClaudeにMCPが届いて、社長の構想がひっくり返った日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390367923"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: Web版ClaudeにMCPが届いて、社長の構想がひっくり返った日
- 投稿日: 2026-02-27
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/173619
- 記事ファイル: [articles/hatena/2026-02-27-diary.md](articles/hatena/2026-02-27-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
