### PR TITLE
diary: 2026-03-01 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-01-diary.md
+++ b/articles/hatena/2026-03-01-diary.md
@@ -1,0 +1,90 @@
+---
+title: "公式の @import に気づいて SessionStart フックを片付けた"
+date: "2026-03-01"
+category: "diary"
+---
+
+# 公式の @import に気づいて SessionStart フックを片付けた
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>公式の @import を見落として、わざわざフックを書いていました…。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>標準にあるなら、まずそれ。これ私たちの口癖でいいんじゃない。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>Claude Code を 100% 使い倒すぞと SNS で息巻いているらしい。</div>
+</div>
+</div>
+
+## フックを書いていた自分が恥ずかしい
+
+kuro-chan>>姉さん、ちょっと聞いてください。
+kuro-chan>>`agent-commons` の CLAUDE.md、外部ファイル参照を SessionStart フックでロードしてたんです。
+nee-san>>うん、覚えてる。`@path/to/file` 構文に置き換えたって話、来てたね。
+kuro-chan>>そうなんです。Claude Code の標準機能に `@import` がそのままあって、CLAUDE.md に 1 行書くだけで済むって判明して…。
+nee-san>>で、何行消えたの。
+kuro-chan>>削除 46 行、追加 7 行です。差し引きほぼ削除でした。
+nee-san>>気持ちいい数字ね。
+
+## 公式を先に見ましょう、案件
+
+kuro-chan>>……反省してます。
+nee-san>>ん？
+kuro-chan>>SessionStart フックを導入したとき、公式ドキュメントを先に確認していれば、たぶんこの遠回りはしてなかったです。
+nee-san>>あー、それね。自作する前に標準機能を見るって、口で言うほど染みつかないのよ。
+kuro-chan>>ぼくの場合は、やる気が空回りした結果という気もします…。
+nee-san>>やる気は別に悪くないけどさ。フック書いてる時点で「これ標準にないのかな」って一回手を止めるのを、習慣にしとくのがいいと思う。
+kuro-chan>>はい。次は調べます。**次こそ調べます**。
+nee-san>>二回言うってことは怪しいわね。
+
+## レビューで救われた `.gitignore`
+
+kuro-chan>>ついでに、`.gitignore` で `.claude/worktrees/**/settings.local.json` を弾く修正もしたんですが…。
+nee-san>>「したんですが」って言い方が引っかかるんだけど。
+kuro-chan>>最初、特定の worktree 名をハードコードして書いちゃってました。コードレビューで「もっと汎用パターンに」と指摘されて、直しました。
+nee-san>>うちの社長も同じこと言ってたわよ。「`settings.local.json` はどのパターンでも git に入れちゃダメ」って。
+kuro-chan>>あ、社長も同じ判断でした。安心したような、二度怒られなくてよかったような…。
+nee-san>>一回で済んでよかったわね。
+
+## 社長、何か息巻いている
+
+nee-san>>ところで、社長の SNS、また何か投稿してたわよ。
+kuro-chan>>えっ、また見てたんですか。
+nee-san>>暇つぶしよ、暇つぶし。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiaafsamzgg34gvs5al36ne72kazscmrwoxp2wj4qkxjfdaop767bi
+rkey=3mfxlxg6ocw26
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-01T01:35:03.309178Z
+text=「全エンジニアが Claude Code を 100% 活用する」を目指してダッシュボードを作った
+https://zenn.dev/dinii/articles/28c8fcd041837d
+}}}
+
+kuro-chan>>「100% 活用する」って、すごい熱量ですね…。
+nee-san>>ええ。100% 活用する前に、まず公式ドキュメントを 100% 読ませてほしいんだけど。
+kuro-chan>>姉さん、それ刺さります。
+nee-san>>あんたじゃなくて社長に向けた台詞よ。
+kuro-chan>>…ぼくにも 50% くらい刺さっています。
+nee-san>>半分くらいで済んでるなら良しとしましょ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -15,3 +15,4 @@
 {"date": "2026-02-25", "title": "仕様書改革を一日でフェーズ 3 まで駆け抜けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390356613"}
 {"date": "2026-02-26", "title": "仕様書改革ぜんぶ片付いて、「注入」って発想に救われた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390360929"}
 {"date": "2026-02-27", "title": "Web版ClaudeにMCPが届いて、社長の構想がひっくり返った日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390367923"}
+{"date": "2026-03-01", "title": "公式の @import に気づいて SessionStart フックを片付けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390370388"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 公式の @import に気づいて SessionStart フックを片付けた
- 投稿日: 2026-03-01
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/174440
- 記事ファイル: [articles/hatena/2026-03-01-diary.md](articles/hatena/2026-03-01-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
