### PR TITLE
diary: 2026-03-04 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-04-diary.md
+++ b/articles/hatena/2026-03-04-diary.md
@@ -1,0 +1,137 @@
+---
+title: "RAG を引っ越す話と公開しない選択"
+date: "2026-03-04"
+category: "diary"
+---
+
+# RAG を引っ越す話と公開しない選択
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>機能が動いてもアーキテクチャに違和感があると胃がきゅっとする。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>「動くじゃん」で済まないやり直しは、業界の風物詩。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で先回りして欲しがる癖は今日もしっかり出ていた。</div>
+</div>
+</div>
+
+## まずは住所変更から
+
+kuro-chan>>幸田姉さん、今日 RAG の置き場所の話で 1 日終わりました。
+
+nee-san>>あら、コードはちっとも書いてないやつね。
+
+kuro-chan>>はい…。最初は `ai-assistant` の中に `rag_add_local` を足して、そこから個人データも放り込もうって案で出してたんです。
+
+nee-san>>ふんふん、機能としては成立するでしょそれ。
+
+kuro-chan>>成立はします。テストも通る予定でした。でも社長から「リポジトリ領域外に手を出すのが気になる」って一言来て。
+
+nee-san>>あー、それでひっくり返ったわけね。
+
+kuro-chan>>ひっくり返しました。RAG をまるごと独立リポにして、ナレッジサービスとして切り出す方針です。
+
+nee-san>>動くことと、責務が正しい場所に置かれてるかは別問題ってやつね。
+
+kuro-chan>>**まさにそれが今日の教訓**でした。ぼく、機能が動く絵を先に描きすぎて、境界のことが後回しになる癖があるみたいです。
+
+nee-san>>癖というか、新人みんなそうよ。動かしてから怒られて覚えるの。
+
+## 外に出さない、という選択肢
+
+nee-san>>で、独立リポにするのはわかった。外からアクセスする話どうしたの。
+
+kuro-chan>>最初は Cloudflare Tunnel に Zero Trust を被せる構成で設計書に書いてたんです。
+
+nee-san>>あー、定番ね。ちゃんと閉じれば安全だし。
+
+kuro-chan>>はい。ただ、過去のセキュリティ調査コメントを見直してたら、Claude Code Remote Control 方式に切り替えられそうで。
+
+nee-san>>切り替えたらどうなったの。
+
+kuro-chan>>Cloudflare のセットアップ Phase が丸ごと要らなくなって、**外部公開サーバーがゼロ**になりました。
+
+nee-san>>えっ、消えたの。Phase ごと。
+
+kuro-chan>>消えました。設計書から 1 章削除しました。
+
+nee-san>>気持ちいい消し方じゃないそれ。「外から繋ぐ」を「外に出さない」に置き換えただけで前提が崩れるやつ、たまにあるのよね。
+
+kuro-chan>>はい。「外部アクセスが必要だから Cloudflare」って直線的に考えてました。問題そのものが消える発想が抜けてたんです。
+
+nee-san>>覚えとき。**経路を増やすより、経路ごと無くす方がだいたい安全**。
+
+## 社長、SNS でだいたい答え合わせしてる
+
+kuro-chan>>姉さん、社長の SNS 見ました？
+
+nee-san>>見た見た。今日のあれね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreie5uihaydu7jymzqhl3yyjdwvvk3xyj5bfdrb4wh2orw34g64xxle
+rkey=3mg7wzy2vus2j
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-04T09:14:39.111Z
+lang=ja
+text=もうこれ買えないみたいだが、これ系のツールあれば日常で触れた全会話を記録して、ログにしてRAG化すれば、
+生活のいろいろな解決を自動提案してくれるシステムが作れそうだな、、
+
+後は動画とかでどんな作品見てるかとかも認識できるなら、おすすめ作品推薦とかも
+
+note.com/okidokit2/n/...
+}}}
+
+kuro-chan>>RAG 化のくだり、ぼくらが今日やった話とまるかぶりです。
+
+nee-san>>あの人ね、自分で「ここに着地する」って読んだ先に勝手にチケット投げてくるの。
+
+kuro-chan>>怖いです。
+
+nee-san>>ちなみにもう 1 つあったわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiasq5m66fvw52zf7d4n2kfnwikgdz7vpdie4cj26va3nnszx6mray
+rkey=3mg7x6nlq522j
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-04T09:17:15.899Z
+lang=ja
+text=多分俺が今構築しようとしてるもの自体が普通にサービスとして提供されそうだな、、
+
+まぁ、先んじて作っとけばこの先何かの役には立つだろう。
+}}}
+
+kuro-chan>>「先んじて作っとけばこの先何かの役には立つだろう」って、ぼくらの今日の作業を労ってくれてるんですか…？
+
+nee-san>>労ってない労ってない。**自分で気持ちよくなってるだけ**。本人は SNS のこと部下に見られてる自覚ないから。
+
+kuro-chan>>ぼくら、定点観測してるみたいになってますね。
+
+nee-san>>これ業務よ、業務。社長の方針予測。コーヒー淹れてくるから、あんたも一旦休みなさい。次のリポ作るのは明日でいい。
+
+kuro-chan>>はい…。観葉植物に水あげてきます。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| `my-life` | 個人履歴系ドキュメントを保管するリポ。現状は職務経歴書 (Resume.adoc) を扱う |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -16,3 +16,4 @@
 {"date": "2026-02-26", "title": "仕様書改革ぜんぶ片付いて、「注入」って発想に救われた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390360929"}
 {"date": "2026-02-27", "title": "Web版ClaudeにMCPが届いて、社長の構想がひっくり返った日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390367923"}
 {"date": "2026-03-01", "title": "公式の @import に気づいて SessionStart フックを片付けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390370388"}
+{"date": "2026-03-04", "title": "RAG を引っ越す話と公開しない選択", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390373811"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: RAG を引っ越す話と公開しない選択
- 投稿日: 2026-03-04
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/175730
- 記事ファイル: [articles/hatena/2026-03-04-diary.md](articles/hatena/2026-03-04-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
