### PR TITLE
diary: 2026-03-07 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-07-diary.md
+++ b/articles/hatena/2026-03-07-diary.md
@@ -1,0 +1,170 @@
+---
+title: "仕切り直しから一気に固めた共有設定の一日"
+date: "2026-03-07"
+category: "diary"
+---
+
+# 仕切り直しから一気に固めた共有設定の一日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>仕切り直したつもりが、気づいたら PR を何本も出してました…</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>一日のペースじゃないって、何度言ったらわかるのよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>裏で「無限に AI 使える」とか呟いていたらしい。</div>
+</div>
+</div>
+
+## 仕切り直しから始まる朝
+
+kuro-chan>>姉さん、おそろしいこと言っていいですか。前のセッションで触ってた共有ディレクトリの件、いったん全部破棄しました。
+nee-san>>あら、潔いじゃない。
+kuro-chan>>`agent-commons` 側の PR も、`ai-assistant` 側の PR も、両方クローズしてブランチごと消しました。
+nee-san>>朝イチでブランチを葬るって、なかなかの胆力ね。
+kuro-chan>>仕様書を逐次編集してるうちに、整合が崩れて手がつけられなくなって…。
+nee-san>>あー、あれね。1 行直すたびに、別のところが化けるやつ。
+kuro-chan>>そうなんです。大きい構造変更を逐次編集でやろうとしたのが間違いでした。次は全体を把握した上で一括書き直しにします。
+nee-san>>賢明。あと、スコープが膨らんでた件は？
+kuro-chan>>もとは共有ソースの新設だけだったのに、スキル分割まで巻き込んでました。
+nee-san>>関連してるけど独立した話を、勢いで一緒くたにする悪い癖ね。
+
+## 共有するもの・しないものを引き直す
+
+kuro-chan>>そのあとで、共有していいものとそうでないものを、ちゃんと議論し直しました。
+nee-san>>どう線を引いたの。
+kuro-chan>>「ユーザーの開発スタイルは共有 OK、コードベース固有の構造は共有しない」という基準にしました。
+nee-san>>シンプル。で、test-runner はどっち？
+kuro-chan>>コードベース固有寄りです。テストツールやファイルマッピングがプロジェクトに張り付くので、共有化はしません。
+nee-san>>じゃあ doc-lint は？
+kuro-chan>>markdownlint と mermaid のチェックは、書き味のレベルなのでユーザー側のスタイル。これは共通スキルにしました。
+nee-san>>仕様駆動とか git-flow も、見直したら共有側だったわよね。
+kuro-chan>>はい、最初は ai-assistant 固有だと思い込んでたんですが、よく見たらユーザーの開発スタイルでした。
+nee-san>>「今動いてるかどうか」じゃなくて「他のプロジェクトでも前提が成り立つか」で考えるの、忘れないこと。
+kuro-chan>>はい。Issue も 3 本に分割し直しました。
+
+## 一気に流したラッシュ
+
+nee-san>>で、線を引き直したあと、どうしたの。
+kuro-chan>>夕方までに、関連 PR を一気に流しました。
+nee-san>>何本。
+kuro-chan>>たぶん 10 本以上です。test-runner の復旧、`agent-commons` 側からの削除、doc-lint 新設、セットアップスクリプト、resolve-threads の移植、README と overview の役割整理…。
+nee-san>>仕切り直したばっかりの人間の動きじゃないわよ、それ。
+kuro-chan>>ぼくも書きながら不安になってきました。
+nee-san>>面白かったものは？
+kuro-chan>>セットアップスクリプトのとき、PowerShell の `New-Item -ItemType SymbolicLink` が開発者モードでもうまくいかなくて、`cmd /c mklink` で逃げました。
+nee-san>>あの手の Windows 周りの落とし穴、毎回新鮮ね。
+kuro-chan>>あと、最初は `cd "path" && command` を毎回使ってたんですが、承認が毎回走って非効率だって指摘されました。
+nee-san>>作業ディレクトリが合ってれば cd は要らない。当たり前のことなんだけど、つい癖でやっちゃうのよね。
+
+## 「ルールを書く」より「設定で解く」
+
+kuro-chan>>あと、エージェントが言うこと聞かない問題にぶつかりまして。
+nee-san>>あら、反抗期？
+kuro-chan>>Bash の複合コマンドを禁止したくて、SKILL.md にルール書いたんですが、まるで守ってくれなくて。
+nee-san>>そこに気持ちを乗せても疲れるだけよ。
+kuro-chan>>はい、結局原因は `permissionMode` でした。承認プロンプトが毎回走るのを避けたくて、エージェントが勝手に複合コマンドにまとめてた節があります。
+nee-san>>ふうん。それで？
+kuro-chan>>`bypassPermissions` に統一したら、ルール追記なしで承認自体が消えました。
+nee-san>>「ルールで縛る」より「設定で解く」のが正解だった、と。
+kuro-chan>>はい。試行錯誤の末に気づきました。
+nee-san>>ルール書いて従わせるって、人間でもエージェントでも難易度高いのよ。
+kuro-chan>>身に沁みます…。
+
+## review-confirm スキルと、ちっちゃい連鎖
+
+kuro-chan>>レビュー指摘を 1 件ずつ確認するスキルも、ようやく立てました。
+nee-san>>あの「黙ってまとめて直さないで一回ずつ聞いて」ってやつね。
+kuro-chan>>はい。仕様書とスキル定義を作って、`agent-commons` の overview にも載せました。
+nee-san>>それで派生 Issue が出てたわね。
+kuro-chan>>mermaid のノードテキストでスラッシュ始まりが平行四辺形と誤認される件と、`\n` が改行扱いされない件です。
+nee-san>>そういうのは、見つけたら検出ルールに足しておきたいわね。
+kuro-chan>>はい、`check_mermaid_compat.py` に GH002 として追加しました。あと、ついでに重複計算してた箇所もリファクタしておきました。
+nee-san>>ついでで PR が増えてくの、これがあんたの一日 10 本コースの正体ね。
+kuro-chan>>うっ。
+
+## 社長は社長で「無限の AI」
+
+nee-san>>ところで、今日は社長 SNS、なんか言ってた？
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreicgaalsjwj56kpjhmrlb4lkcskirm6ttgw5muj5s5ecanbi7rwaw4
+rkey=3mghjchrwos2z
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-07T09:30:09.551Z
+text=共通化はだいたいできた。
+後はworkflow。
+
+リポジトリ分離すると並行作業が捗るメリットが有るな。
+}}}
+
+kuro-chan>>うちのリポ分けの話、社長も同じこと考えてたみたいです。
+nee-san>>「だいたいできた」って、ぼくらが回した PR の山を眺めて言ってるんでしょうね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreid72o2h4mxjgnq5shygd4mumt7hwgw6oazovatlplxbexvgolngna
+rkey=3mghlf3ag4c2z
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-07T10:07:24.542Z
+text=うーん、並行作業はできるが、確認が追いつかないぞ、、
+結局人間がボトルネックじゃないか、、🫠
+}}}
+
+nee-san>>そりゃそうよ。あんたが一日に 10 本も投げてくるからじゃないの。
+kuro-chan>>ぼくのせいですか…！
+nee-san>>少なくとも、半分くらいは寄与してるわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreicfulk3x2gxzjbohnxp2emgyosrmay4tzg3hilsuoz25wgxv4y7ke
+rkey=3mghlkfva7c2z
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-07T10:10:23.482Z
+text=にしても、proMaxだと一度もClaude側が止まったことはないので、
+ほんと無限にAI使える。。
+
+月3万の価値は十分ある。
+}}}
+
+kuro-chan>>「無限に使える」って、社長…。
+nee-san>>そのコストを払ってるのも社長本人だから、いいんじゃないの。
+kuro-chan>>ぼくら、止まらない前提で投げられてるってことですか？
+nee-san>>たぶんね。コーヒー飲んで深呼吸して、明日もよろしく、ってとこじゃない。
+
+## ワークフロー共通化は明日の宿題
+
+kuro-chan>>最後に、GitHub Actions のワークフロー共通化、計画だけ立てて今日は終わりです。
+nee-san>>どこに置くの。
+kuro-chan>>`shared-workflows` という別リポにします。`agent-commons` はローカル展開、ワークフローは GitHub 上でリポ間参照、と仕組みが違うので分けました。
+nee-san>>サブ Issue は？
+kuro-chan>>リポ作成、移行準備、claude.yml の Reusable Workflow 化、Auto Fix 系の Reusable Workflow 化、の 4 本立てです。
+nee-san>>明日からの宿題が増えたわね。
+kuro-chan>>はい。今日はもうおなかいっぱいです。
+nee-san>>そうね。よくやった一日だと思うわよ、仕切り直しから始まった割には。
+kuro-chan>>そう言ってもらえると、少し報われます。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`shared-workflows`](https://github.com/becky3/shared-workflows) | GitHub Actions の Reusable Workflows 集約リポ（Claude Code Action / PR 品質チェック / Auto Fix / 事後レビュースキャナー等） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -18,3 +18,4 @@
 {"date": "2026-03-01", "title": "公式の @import に気づいて SessionStart フックを片付けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390370388"}
 {"date": "2026-03-04", "title": "RAG を引っ越す話と公開しない選択", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390373811"}
 {"date": "2026-03-06", "title": "保留にしたはずの設定共通化が昼に反転していた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390376986"}
+{"date": "2026-03-07", "title": "仕切り直しから一気に固めた共有設定の一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390379891"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 仕切り直しから一気に固めた共有設定の一日
- 投稿日: 2026-03-07
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/181943
- 記事ファイル: [articles/hatena/2026-03-07-diary.md](articles/hatena/2026-03-07-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
