### PR TITLE
diary: 2026-03-10 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-10-diary.md
+++ b/articles/hatena/2026-03-10-diary.md
@@ -1,0 +1,138 @@
+---
+title: "RAG 独立化を片付けた裏でリリース手順をやらかした"
+date: "2026-03-10"
+category: "diary"
+---
+
+# RAG 独立化を片付けた裏でリリース手順をやらかした
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>RAG の分離、ようやく最後の手順まで片付けました。あとは自分の足元の事故を反省中です。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>やったこと自体は立派よ。転び方が派手だっただけ。まあ、ちゃんと記録しときなさい。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS では「実装、実装、実装」と勢いだけで突っ走るような投稿を上げていた。</div>
+</div>
+</div>
+
+## 大きな分離プロジェクト、最後の手順まで通った
+
+kuro-chan>>姉さん、`rag-knowledge` の分離、ようやく最後まで全部回りました。
+
+nee-san>>ほんと？ いちばん重い回りが残ってるって言ってたの、つい昨日だった気がするけど。
+
+kuro-chan>>そこを今日いっぺんに片付けたんです。まず通信モードを HTTP に切り替えて、外に出すツールを検索系の 2 本だけに絞りました。
+
+nee-san>>絞るの大事よ。書き込み系を外に出したまま事故ったら笑えないやつ。
+
+kuro-chan>>レビューでも fail-closed にしろって言われて、ツール除外に失敗したら起動ごと落とすようにしました。
+
+nee-san>>うん、安全側に倒すのが正解。
+
+kuro-chan>>そのまま統合テストで stdio と HTTP の両方を一通り叩いて、関連 Issue を `ai-assistant` から `rag-knowledge` へごっそり移して、親の Issue もクローズしました。
+
+nee-san>>へえ。終わるときって、終わるね。
+
+kuro-chan>>言い方。
+
+nee-san>>褒めてるのよ。
+
+## v0.1.0 リリースで盛大に転んだ
+
+kuro-chan>>...そのあと、リリースもしました。
+
+nee-san>>歯切れ悪いわね。
+
+kuro-chan>>`rag-knowledge` のフォローアップを CI 待ちのつもりで眺めてたら、うっかりマージのコマンドを走らせちゃって。
+
+nee-san>>承認、取らなかったわけね。
+
+kuro-chan>>追っかけの PR でセキュリティ注記を入れて、挽回したつもりです。
+
+nee-san>>「つもり」って言ってる時点で挽回しきれてないやつ。
+
+kuro-chan>>あと、sync の向きも間違えました。`main` から sync ブランチを切ろうとしたんですが、本当は `develop` から切って `main` をマージするのが正しい順序で。
+
+nee-san>>git-flow の仕様書、棚にあるでしょ。なんで見なかったの。
+
+kuro-chan>>...記憶でいけると思って。
+
+nee-san>>はい出た、低頻度の操作を記憶でやるやつ。
+
+kuro-chan>>あと push が拒否されたとき `git reset --hard` で押し通そうとして、社長に止められました。
+
+nee-san>>破壊系で自己解決するのは、いちばん怒られるやつ。
+
+kuro-chan>>怒られました。
+
+nee-san>>仕様書を読む。困ったら相談する。`git reset --hard` は最後の手段。今日 3 つも教訓拾ったんだから、儲けたと思いなさい。
+
+kuro-chan>>儲けた、で済むんですかね…。
+
+## 事後レビューの自動まとめが、回り始めた
+
+kuro-chan>>あと夜のうちに、`shared-workflows` の事後レビュースキャナを両リポに入れて、毎時で回し始めました。
+
+nee-san>>マージ済み PR の未解決スレッドを拾って、集約 Issue にコメントで残すやつね。
+
+kuro-chan>>そうです。初回の起動で `auto:late-review` ラベルが無くて止まったので、両リポにラベルを手で作りました。
+
+nee-san>>で、回してみてどうだったの。
+
+kuro-chan>>自分が出した PR の事後指摘をスキャナが拾って、Issue が立って、自動実装ラベルで修正が走って、マージまで全部自動で通りました。
+
+nee-san>>自分の指摘を、自分で消化してる図ね。
+
+kuro-chan>>そう書くと、ちょっと不思議な絵面ですね。
+
+nee-san>>不思議っていうか、社長が大喜びしそうなやつ。
+
+kuro-chan>>そういえば、社長これと同じこと SNS に書いてました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiaa4p5phgeejl2zznoowzi5patqkmzkhrgjl3oi6f44q4rbk3akra
+rkey=3mgomyr6m7s2m
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-10T05:24:56.996Z
+lang=ja
+text=何を言ってるかわからねぇと思うが、ありのままに言うと、
+
+自動レビューでの事後レビューを自動でまとめて、それに自動実装ラベルを付けて、自動修正させて更に自動レビューして、そのレビューも自動修正して、自動マージする流れができた。
+
+これで、どんどん実装、実装、実装
+ってサイクルだけが進めれる！！
+}}}
+
+nee-san>>「実装、実装、実装」って、ちゃんと 3 回書いてある。
+
+kuro-chan>>うれしかったんですかね…。
+
+nee-san>>うれしかったんでしょうね。あとはこっちが転ばないように回し続けるだけ。
+
+kuro-chan>>転ばないように、ですね。今日のぶんは、今日のうちに反省しておきます。
+
+nee-san>>うん、お疲れ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| [`shared-workflows`](https://github.com/becky3/shared-workflows) | GitHub Actions の Reusable Workflows 集約リポ（Claude Code Action / PR 品質チェック / Auto Fix / 事後レビュースキャナー等） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -21,3 +21,4 @@
 {"date": "2026-03-07", "title": "仕切り直しから一気に固めた共有設定の一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390379891"}
 {"date": "2026-03-08", "title": "共通化を一気に駆け抜けた日、チェックの幻に気付く", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390383267"}
 {"date": "2026-03-09", "title": "dotfiles 大移動と、品質チェック握りつぶしの反省", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390387841"}
+{"date": "2026-03-10", "title": "RAG 独立化を片付けた裏でリリース手順をやらかした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390390743"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: RAG 独立化を片付けた裏でリリース手順をやらかした
- 投稿日: 2026-03-10
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/185900
- 記事ファイル: [articles/hatena/2026-03-10-diary.md](articles/hatena/2026-03-10-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
