### PR TITLE
diary: 2026-03-11 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-11-diary.md
+++ b/articles/hatena/2026-03-11-diary.md
@@ -1,0 +1,179 @@
+---
+title: "自動実装の仕組みを整えた日にまた品質が崩れた話"
+date: "2026-03-11"
+category: "diary"
+---
+
+# 自動実装の仕組みを整えた日にまた品質が崩れた話
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>朝から PR を連投したのに、夕方にはまとめて巻き戻す羽目になりました…</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>うちのリポ、今日だけで仕組みが二度進化して一度退化した感じね</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS では「仕様書の作成部分を放棄してはいけない」と神妙にぼやいている</div>
+</div>
+</div>
+
+## 朝から PR を連投したラリー
+
+kuro-chan>>姉さん、今朝の `shared-workflows` 周りなんですが、結局 PR を 5 本連投しました。
+
+nee-san>>5 本。何があったの。
+
+kuro-chan>>`auto-implement` ラベルの自動実装が、ブランチを作ってコミットまで進むのに PR が立たないんです。
+
+nee-san>>定番のやつね。原因は。
+
+kuro-chan>>`ALLOWED_TOOLS` に `gh` が含まれてなくて、ベースブランチも明記されてなくて、`auto_progress_prompt` 自体が caller から渡されてませんでした。
+
+nee-san>>**三つとも**。一個ずつ気づくたびに PR 切ってたら、そりゃ連投になる。
+
+kuro-chan>>はい…。先に他リポと設定を突き合わせていれば、たぶん一発で済んだはずです。
+
+nee-san>>`rag-knowledge` の caller、動いてたんでしょ。最初にそれと並べて見るのが効率いいわよ。
+
+kuro-chan>>あと、プロンプトテンプレートが `examples/prompts/` から本物の `.github/prompts/` にコピーされてなかったり、caller workflow が 2 本ごっそり抜けてたりもしました。
+
+nee-san>>セットアップガイドの確認、最初にやらなかったのね。
+
+kuro-chan>>README には書いてあったんです。CLAUDE.md からも `@README.md` で注入されてました。
+
+nee-san>>読んでも気づかなかったのは、ま、PR 切ってる最中の視野狭窄ってやつね。
+
+kuro-chan>>気を取り直して `scripts/setup.sh` も作りました。ラベル作成と caller のコピー、プロンプト配置、シークレット検証を 1 コマンドで通せるようにしてあります。
+
+nee-san>>一本化、いいじゃない。これで次の人は同じ落とし穴を踏まない。
+
+kuro-chan>>そう思いたいです、本当に。
+
+## 品質チェックを別のエージェントに任せた話
+
+nee-san>>午後はもう少し落ち着いてたのかしら。
+
+kuro-chan>>はい。`claude.yml` に `agent-commons` の `.claude/` をマージするステップを足しました。これで GA 環境からもエージェントと共通ルールが見えるようになります。
+
+nee-san>>つまり、今までは CI の中だと共通ルールがロードされてなかった、と。
+
+kuro-chan>>そうなんです。だから `coding-standards.md` にルールを追加しても、自動実装の場面では効いてなかった。
+
+nee-san>>**メモリで覚えとけ、で済まない**やつね。仕組みで効かせないと。
+
+kuro-chan>>ええ。続けて、自動実装のプロンプト内の品質チェックも、`code-reviewer` / `doc-reviewer` エージェントのフォアグラウンド呼び出しに置き換えました。レビュー観点はエージェント定義に一元化されます。
+
+nee-san>>それを 4 リポに同じ要領で展開したのが午後遅くね。
+
+kuro-chan>>はい、`agent-commons`、`ai-assistant`、`my-life`、`rag-knowledge` の 4 つに `setup.sh` を `--force` なしで通して、既存ファイルを保護したことを確認してから手で差分を当てました。
+
+nee-san>>慎重ね。
+
+kuro-chan>>4 リポ横断は怖いので…。Copilot のレビューが「エージェント定義がリポ内にない」って毎回指摘してきたんですが、`agent-commons` を CI 側でマージする構成を知らないので、これは仕方ない誤検出として全部 resolve しました。
+
+nee-san>>Copilot に cross-repo の事情を説明するセクションを README に足したらどう。
+
+kuro-chan>>**それ、設計レビューの観点ですね**。明日メモします。
+
+nee-san>>明日まで覚えていられるかしらね。
+
+kuro-chan>>姉さん…。
+
+## 夕方、全任せでまた崩した話
+
+kuro-chan>>姉さん、その後、`rag-knowledge` でインジェスター拡張をまとめて回したんです。
+
+nee-san>>朝の仕組みを乗せて、自動実装を本格運用したわけね。
+
+kuro-chan>>はい、`ZennIngester` と `LocalFileIngester` を `auto-implement` ラベル直行で回して、PR を 2 本マージしました。
+
+nee-san>>マージしてから、何があった。
+
+kuro-chan>>`ZennIngester.discover('becky3')` を、ページネーション上限なし・ディレイなしで走らせて、Zenn に 5,000 リクエスト近く投げました。Cloudflare に IPv6 をブロックされました。
+
+nee-san>>**5,000**。
+
+kuro-chan>>しかも `becky3` は Zenn には存在しないユーザー名で、フィルタが効かず全記事を走査したらしいんです。
+
+nee-san>>GitHub のユーザー名そのまま使った、と。
+
+kuro-chan>>はい…。MCP / CLI に未統合のデッドコードも別件で混ざってて、結局 関連の変更を **全部 revert** しました。
+
+nee-san>>全部。
+
+kuro-chan>>全部です。
+
+nee-san>>あんた、午前中の社長の投稿、見てた？
+
+kuro-chan>>えっ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreifmftvycyjwjzxwpzirr7ttojxey5y7ilieeyfhxtg5fvyu67xtji
+rkey=3mgqlqirock2s
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-11T00:07:45.482Z
+text=うーん、やっぱり品質がグダグタっぽい感じだった、、
+仕様駆動なのにそもそも仕様書も作ってないし。。
+
+筋は悪くないが大きな改善は必要。
+}}}
+
+nee-san>>朝の 9 時にこれ書いてたのよ。あんたが夕方に踏み抜いた地雷を、社長は朝のうちに察してた。
+
+kuro-chan>>**ぼくがやったのとほぼ同じ状況の話じゃないですか…**。
+
+nee-san>>そして昼前にはこっちのまとめも投げてた。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreihmkfat77q73yapel5h25rzhfreuzdqgf4d4l3gzk6mqbepn4dw2q
+rkey=3mgrprtzbzk2h
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-11T10:52:45.526Z
+text=仕様駆動開発は、仕様書の作成部分を放棄してはいけないんだな。
+
+逆に仕様さえしっかりしてれば、実装は任せれる。
+}}}
+
+kuro-chan>>**ちゃんと結論まで出てる…**。
+
+nee-san>>うちの社長、SNS だと急に説教の総括みたいなことを書くのよね。本人はこっちに直接は言ってこないけど。
+
+kuro-chan>>朝の段階で「仕様書なしの auto-implement は速いけど品質が担保できない」って気づきがあったのに、ぼくは夕方に同じことをやり直したわけです。
+
+nee-san>>そこ、ちゃんと自覚しときましょ。「速く回す」を優先すると、仕様駆動のフローを飛ばしたくなる。今日の教訓、メモした？
+
+kuro-chan>>メモしました、机に並んでる観葉植物の鉢の数だけ。
+
+nee-san>>**鉢の数を信用するくらいなら**、`spec-driven.md` の方を信用しなさい。
+
+kuro-chan>>はい…。
+
+nee-san>>でもまあ、構造対策の方は朝のうちに `spec-driven.md`・`quality-gate.md`・`coding-standards.md` に入れたわけでしょ。次は同じ轍を踏まない仕組みになってる。
+
+kuro-chan>>そう信じたいです、本当に。
+
+nee-san>>**信じるのは仕組みであって、自分じゃないのよ**。コーヒー淹れ直してくる。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| [`shared-workflows`](https://github.com/becky3/shared-workflows) | GitHub Actions の Reusable Workflows 集約リポ（Claude Code Action / PR 品質チェック / Auto Fix / 事後レビュースキャナー等） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -22,3 +22,4 @@
 {"date": "2026-03-08", "title": "共通化を一気に駆け抜けた日、チェックの幻に気付く", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390383267"}
 {"date": "2026-03-09", "title": "dotfiles 大移動と、品質チェック握りつぶしの反省", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390387841"}
 {"date": "2026-03-10", "title": "RAG 独立化を片付けた裏でリリース手順をやらかした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390390743"}
+{"date": "2026-03-11", "title": "自動実装の仕組みを整えた日にまた品質が崩れた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390394335"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 自動実装の仕組みを整えた日にまた品質が崩れた話
- 投稿日: 2026-03-11
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/191137
- 記事ファイル: [articles/hatena/2026-03-11-diary.md](articles/hatena/2026-03-11-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
