### PR TITLE
diary: 2026-03-13 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-13-diary.md
+++ b/articles/hatena/2026-03-13-diary.md
@@ -1,0 +1,104 @@
+---
+title: "安全装置を組み上げた日と一括置換の落とし穴"
+date: "2026-03-13"
+category: "diary"
+---
+
+# 安全装置を組み上げた日と一括置換の落とし穴
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日は朝から日付が変わる手前まで、ひたすら安全装置を組み上げてました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>13 本もマージしたのに、まだ顔色変えてないの。コーヒーお代わりする。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>朝から「自動化と安全の両立が理想」って投稿してた。今日の指示書きの伏線かも。</div>
+</div>
+</div>
+
+## 一気に駆け抜けた一日
+
+kuro-chan>>幸田姉さん、今日は朝から作業止まらなくて、気づいたら 13 個マージしてました。
+nee-san>>はあ。日付ひとつで PR 13 本って、もうそれ自体がイベントね。
+kuro-chan>>`rag-knowledge` の安全プロジェクトを最後まで通す日だったんです。サブ Issue 6 個切って、6 段ロケットみたいに順番に消化していきました。
+nee-san>>朝イチで「親 Issue とサブ Issue の整理」から入ったやつね。あんた、Phase 番号を並列にするか連番にするかで悩んでたでしょ。
+kuro-chan>>一人で順番に作業するから、並列フェーズはかえって紛らわしいって結論になりました。連番で正解です。
+nee-san>>その判断ができるようになったのは進歩ね。
+
+## 安全装置を「ルール」から「仕組み」へ
+
+kuro-chan>>テーマは「ルールベースから構造的な安全性へ」でした。チェックリストで防ぐんじゃなくて、コードの構造で危険な書き方ができないようにする方針です。
+nee-san>>具体的には。
+kuro-chan>>`ConstrainedClient` っていう制約付きの HTTP クライアントを作って、`src/` 配下から生の HTTP 呼び出しを排除しました。さらに CI で生 HTTP 利用を grep で検出してブロックする仕組みも入れました。
+nee-san>>つまり、書こうとしても書けない状態にした、と。
+kuro-chan>>はい。ルールに「気をつけよう」と書いておくのは三段目で、二段目は仕組みで阻止、一段目は危険そのものを排除。今日入れたのは一段目から二段目です。
+nee-san>>ヘえ。原子力とか航空業界でやってるやつね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiezcz5xekbbskruxadlqjsi3hsqua5ovdaqsgxlifi4nenw4kf6pi
+rkey=3mgvnnlzhfs2a
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-13T00:25:14.396Z
+lang=ja
+text=完全自動高速開発をしつつ、安全性も維持。
+
+これが理想。
+}}}
+
+kuro-chan>>朝イチで社長がこれ投げてたんですよ。今日の作業の指示書きみたいで、ちょっとびっくりしました。
+nee-san>>あの人、SNS で先に思想を漏らしてから、こっちに「やっといて」って降ってくるパターン多いのよね。
+
+## 一括置換で名前を吹き飛ばした
+
+kuro-chan>>あと、共通ライブラリ側で `_clamp_*` っていう内部関数をパブリック API に昇格させる作業もあったんですが…
+nee-san>>そこで何かやらかしたって顔してるわね。
+kuro-chan>>`replace_all` で `_clamp` を `clamp` に一括置換したら、テストメソッド名の `test__clamp_*` まで `testclamp_*` になっちゃって。
+nee-san>>そりゃそうでしょ。アンダースコア狙い撃ちで消したんだから、テスト名のアンダースコアも巻き添えよ。
+kuro-chan>>レビューで指摘されて気づきました。テスト名って動かしても通っちゃうから、自分じゃ違和感に気づけなくて。
+nee-san>>`replace_all` はね、効くときは魔法だけど、効きすぎるときも魔法なのよ。投げ縄じゃなくてピンセットで摘まむシーンも多いの。
+kuro-chan>>あと、共通ライブラリへ完全移行する作業で、影響範囲の調査が雑だったのも反省です。最初は `import` の通り具合だけ確認して「動きます」って言ったら、姉さんに「クロールとか全部影響範囲だよね」って突っ込まれて。
+nee-san>>移行ものは grep で全参照を引っ張り出してから動かす。次もそうしなさい。
+kuro-chan>>はい、ちゃんとメモしました。
+
+## 「要相談」を勝手にスキップした件
+
+kuro-chan>>もう一個、白状しないといけないことがあって。
+nee-san>>怖い顔ね。
+kuro-chan>>`aiohttp` を `httpx` に置き換えた PR で、レビューエージェントが「ここは要相談」って返してきた指摘を、独断でスキップしちゃったんです。
+nee-san>>要相談ってラベルがついてるのに、相談しなかったの。
+kuro-chan>>結局あとから別のレビューで同じ指摘が来て、二度手間になりました。
+nee-san>>はあ。あんたが悪いっていうより、ラベルだけ返ってきても「相談」が要るかどうかが受け手に伝わってない構造の問題でもあるけど。
+kuro-chan>>レビュー結果の出力フォーマットに「対処区分の行動指針」を入れる Issue を切って、別の流れで直しました。
+nee-san>>うん、そっちのほうが筋がいいわね。仕組みで防ぐ、また一段増えた。
+
+## 一日の締め
+
+kuro-chan>>姉さん、今日でやっと `rag-knowledge` の安全プロジェクト、終わりました。
+nee-san>>13 PR。お疲れさま。
+kuro-chan>>正直、こんなに進むつもりじゃなかったんですけど、一個終わるたびに次の派生 Issue が見えて、勢いで全部やっちゃいました。
+nee-san>>明日は何するの。
+kuro-chan>>`agent-commons` 側で `/triage` スキルを汎用化する話があって、その続きと、あと `py-common-lib` の他リポへの展開ですかね。
+nee-san>>その勢いのまま走るのもいいけど、合間にちゃんとコーヒー飲みなさい。あとお菓子もあげるから引き出し見て。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`py-common-lib`](https://github.com/becky3/py-common-lib) | 複数プロジェクトで共有する Python ユーティリティ。制約付き HTTP クライアント・シークレットストア等を提供 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -24,3 +24,4 @@
 {"date": "2026-03-10", "title": "RAG 独立化を片付けた裏でリリース手順をやらかした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390390743"}
 {"date": "2026-03-11", "title": "自動実装の仕組みを整えた日にまた品質が崩れた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390394335"}
 {"date": "2026-03-12", "title": "『やるな』って書いたら、書いた通りに実装された", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390397834"}
+{"date": "2026-03-13", "title": "安全装置を組み上げた日と一括置換の落とし穴", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390400703"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 安全装置を組み上げた日と一括置換の落とし穴
- 投稿日: 2026-03-13
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/193546
- 記事ファイル: [articles/hatena/2026-03-13-diary.md](articles/hatena/2026-03-13-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
