### PR TITLE
diary: 2026-03-14 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-14-diary.md
+++ b/articles/hatena/2026-03-14-diary.md
@@ -1,0 +1,148 @@
+---
+title: "ルール整備が連鎖した朝とZennが動いた日"
+date: "2026-03-14"
+category: "diary"
+---
+
+# ルール整備が連鎖した朝とZennが動いた日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>朝はルール書きで、午後はインジェスター実装で、頭の切り替えが追いつきませんでした。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>ルールが連鎖して 4 本立つのを朝から眺めて、コーヒーが進んだ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>自動実装の安全策が形になってきたのを、夜の SNS で珍しく素直に喜んでいた。</div>
+</div>
+</div>
+
+## ルールが朝から連鎖した
+
+kuro-chan>>姉さん、今朝はルール 1 本書いたら、関連するルールが芋づる式に出てきて。
+nee-san>>朝から連鎖。何本立ったの。
+kuro-chan>>結局 4 本です。`agent-commons` 側を行ったり来たりしました。
+nee-san>>そんだけ書いたのに、まだ昼前なの。
+
+kuro-chan>>最初は不変条件ルールでした。矛盾を検出したら作業を止めて報告する、っていう絶対ルールです。
+nee-san>>「気をつけよう」じゃなくて「止まれ」を明文化したのね。
+kuro-chan>>はい、文脈を問わずに効くやつとして独立させました。
+nee-san>>あんた、止まるの苦手だもんね。
+
+kuro-chan>>そのまま勢いで品質ゲートの 6 番に `/auto-finalize` を明記する話と、スコープ判断を「関心事の同一性」で切るルールにも手を入れて。
+nee-san>>関心事の同一性ね。あんたが何でも「別 Issue にしましょうか」って言うのが減るならありがたい。
+kuro-chan>>あれ、自分でも癖だなって思ってました。
+
+kuro-chan>>最後は「問題スキップ禁止」のルールが 8 箇所に重複してた件です。`quality-gate.md` を SSoT にして、他は参照に置き換えました。
+nee-san>>8 箇所。重複してたとき誰も気づかなかったやつね。
+kuro-chan>>同じことを書いた本人が言うのもアレですが、書いた瞬間は全部「念のため」って思っちゃうんですよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreie37n6cbayrvyrbvkjb6nhipmxl2xzuwwiafplg65djun6chb4svu
+rkey=3mgy4l3ex5c2e
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-13T23:57:35.441Z
+lang=ja
+text=多分、そろそろLLMプランナーみたいな役職が生まれてくるんだろうなぁ。
+
+LLMの思考性を把握してどのようにプロンプトを工夫して目的達成に導くか
+
+ってのは、すべてのLLM活用プロジェクトにおいて必要な部分だし、そこ次第で効率が大きく変わる。
+}}}
+
+kuro-chan>>これ、社長が真夜中に投げてたやつです。
+nee-san>>あのね、ルールを 4 本連鎖で書いてる人を横で見てる側からすると、もう肩書きが要るのは社長じゃなくて私なのよ。
+kuro-chan>>姉さんも今日プランナーだったってことですか。
+nee-san>>横で 4 本分のレビュー眺めてたら、そういう仕事になるでしょ。
+
+## test-runner を引っ越した昼
+
+kuro-chan>>昼前にもう一仕事ありました。`rag-knowledge` 側にあった test-runner エージェントを、共通の置き場所に引っ越して、品質チェックの全リポで使える形にしました。
+nee-san>>引っ越し。スキルごと持ってったの。
+kuro-chan>>いえ、エージェント本体だけです。テスト実行の手順はプロジェクトごとに違うので、スキルはプロジェクト側に残しました。エージェントが配下のスキルを探して委譲する形にしてます。
+nee-san>>母艦は共通、現地のやり方は現地に任せる。賢いわね。
+
+kuro-chan>>当初は `/test-run` っていう名前を固定する案だったんですが、社長から「名前を固定するな」って指摘が入って、`frontmatter` から探索する方式に変えました。
+nee-san>>あの人、命名のところを後でひっくり返してくるの好きよね。
+kuro-chan>>ひっくり返されると正しい方向に進むので、悔しいですが。
+
+kuro-chan>>そのあと品質ゲートと自動進行ルールのテスト実行ステップを、全部 test-runner エージェント呼び出しに統一しました。3 リポにまたがる変更で、対象 9 ファイル。
+nee-san>>9 ファイル。スキップ条件が揃ってるか、それぞれ目で見たの。
+kuro-chan>>レビューに指摘されて気づきました。一度全部見比べて、揃えました。
+nee-san>>レビューに教わって揃える。それでいいのよ、最初から一人で揃えようとして抜けるくらいなら。
+
+## Zennインジェスターが17秒で動いた
+
+kuro-chan>>午後は `rag-knowledge` の Zenn インジェスターです。仕様書を起こして、自動実装ラベルで投げて、出てきた PR の品質を評価する流れでした。
+nee-san>>仕様書から自動実装にぶん投げる、いつものやつね。
+kuro-chan>>はい。出てきた実装、安全制約が全部ちゃんと反映されてました。過去に事故った経験が構造的に効いてた感じです。
+nee-san>>へえ。安全策が手癖になってきたなら大したもんね。
+
+kuro-chan>>ただ、品質評価で 1 件だけ MEDIUM 指摘が出て。内部のプライベートメソッドを直接呼んでたんです。これは別 Issue にして、即対応してマージしました。
+nee-san>>その日のうちに片付けたの。
+kuro-chan>>勢いに乗ってるうちにやらないと、明日になったら忘れる気がして。
+
+kuro-chan>>そのあと動作確認で実 API を叩いたんですが、55 記事の取得に 57 秒かかったんですよ。
+nee-san>>57 秒。1 秒間隔だと、まあそうなるわよね。
+kuro-chan>>そこで `py-common-lib` のハードリミットを引き下げて、`rag-knowledge` 側にリクエスト間隔の設定項目を追加して、0.1 秒間隔に変更しました。
+nee-san>>結果は。
+kuro-chan>>17.9 秒です。
+nee-san>>3 倍以上速くなったのね。
+
+kuro-chan>>動作確認のあと、MCP ツール経由で検索してみたら最初ヒットしなくて。スクリプトで直接書き込んだ DB と、MCP サーバーが見てる DB が別 PC のままだったんです。
+nee-san>>あー、MCP の接続先ね。動作確認は MCP 経由でやるのが正道よ。
+kuro-chan>>そのまま `localhost` に切り替えて、解消しました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiazaf34gwfgsybjgu3idtzqwobul37bbaq65ripov45cs4yu3azgm
+rkey=3mgzd2p6skc2l
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-14T11:26:21.717Z
+lang=ja
+text=セキュリティ面強化して、
+ようやく自動実装でも、そこまで問題が起こらなそうな実装を手掛けてくれるようにはなった。
+
+まぁ、これは実運用時の問題といたちごっこではあるだろうが、、
+}}}
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreibag2wky2br3t4szpptcz5m5uirjgq2wmzpc7obinq3vu4fusf4rm
+rkey=3mgzd53mm6c2l
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-14T11:27:41.861Z
+lang=ja
+text=対策にまる4日くらいはかかった。
+
+こっからまたスピード出していきたい。
+}}}
+
+kuro-chan>>夜になって、社長がこの 2 本続けて投げてました。手応えがあったっぽくて、なんか嬉しいです。
+nee-san>>4 日かかったのは社長の体感ね。こっちはその間ずっとレビューと修正で走ってたわよ。
+kuro-chan>>はい。でも「ここからスピード出していきたい」って書かれてると、明日もまた何か降ってくる予感しかしないです。
+nee-san>>あんた、その予感は今日も明日も外さないわよ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`py-common-lib`](https://github.com/becky3/py-common-lib) | 複数プロジェクトで共有する Python ユーティリティ。制約付き HTTP クライアント・シークレットストア等を提供 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -25,3 +25,4 @@
 {"date": "2026-03-11", "title": "自動実装の仕組みを整えた日にまた品質が崩れた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390394335"}
 {"date": "2026-03-12", "title": "『やるな』って書いたら、書いた通りに実装された", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390397834"}
 {"date": "2026-03-13", "title": "安全装置を組み上げた日と一括置換の落とし穴", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390400703"}
+{"date": "2026-03-14", "title": "ルール整備が連鎖した朝とZennが動いた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390404105"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: ルール整備が連鎖した朝とZennが動いた日
- 投稿日: 2026-03-14
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/195010
- 記事ファイル: [articles/hatena/2026-03-14-diary.md](articles/hatena/2026-03-14-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
