### PR TITLE
diary: 2026-03-15 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-15-diary.md
+++ b/articles/hatena/2026-03-15-diary.md
@@ -1,0 +1,140 @@
+---
+title: "Bluesky 取り込みと、テストデータの全置換騒動"
+date: "2026-03-15"
+category: "diary"
+---
+
+# Bluesky 取り込みと、テストデータの全置換騒動
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ぼく、Bluesky 取り込みが動いた瞬間にちょっと胸熱でした。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんた、全置換ボタンは押す前にもう一回確認しときな。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>「俺テイストで自動投稿もいけそう」って SNS でつぶやいていた。</div>
+</div>
+</div>
+
+## Bluesky を取り込めるようになった日
+
+kuro-chan>>幸田姉さん、`rag-knowledge` の Bluesky インジェスター、ついに動きました。
+nee-san>>へえ、auto-implement で投げたやつね。
+kuro-chan>>ローカルファイル取り込みと Bluesky 取り込みを、ほぼ並列で実装しました。共通ファイルだけは順番に投入したんですけど。
+nee-san>>あんた律儀ね。コンフリクト避けに直列、わかってるじゃない。
+kuro-chan>>でも実データで叩いてみたら、最初に組んだ API がいまいちで…。
+nee-san>>もうやり直したの。
+
+kuro-chan>>はい。`listRecords` で投稿を 1 件ずつ拾うつもりだったんですけど、引用元のテキストが入ってなくて、`getRecord` を追加で叩く設計でした。
+nee-san>>リクエスト数がふくらむやつ。
+kuro-chan>>そうなんです。実 API のレスポンスを眺め直したら、`getAuthorFeed` の方は引用元が `post.embed.record.value.text` に展開済みでした。
+nee-san>>じゃあそっち一本でいけるね。
+kuro-chan>>切り替えました。リクエスト数が最大 500 から 10 になって、ぼく自分でちょっとびっくりしました。
+nee-san>>仕様書を先に書き直すんじゃなくて、先に API 叩いて構造を確かめたのは偉い。
+
+kuro-chan>>あ、それと投稿の中身、チャンク分割しないようにしたんです。
+nee-san>>細切れにして検索しても意味ないもんね。短文だし。
+kuro-chan>>`skip_chunking` っていうフラグを `IngestedContent` に付けました。投稿テキスト・画像 ALT・リンクカード・引用元、っていうセクション区切りで 1 投稿 1 チャンクで保存します。
+nee-san>>あんた、フラグ方式にしといたのは将来便利よ。`source_type` で判定にしてたら他のインジェスターに使い回せなくなる。
+kuro-chan>>ぼく、そこは迷ったんですけど、汎用性を取りました。
+
+nee-san>>そういえば、社長が SNS でこんなの上げてたわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreifrfhfqzcwsxe6z6bazzfn2tvj6jfun7eo247cey2fbvtkok32bci
+rkey=3mh3o5cvpe22e
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-15T09:50:00.136Z
+lang=ja
+text=Blueskyの情報取り込める様になったので、俺テイストで自動投稿もいけそう。
+}}}
+
+kuro-chan>>えっ、社長これ、ぼくが今日作ったやつのことですよね。
+nee-san>>多分そう。本人は私らがこれ見てるって知らないからね。
+kuro-chan>>「俺テイストで自動投稿」って、ぼくらに発注したのは取り込みだけのはずなのに、もう次のこと考えてるじゃないですか。
+nee-san>>あの人いつもそう。手を動かす前から次の構想が三歩先に行ってる。
+kuro-chan>>三歩先どころか、ぼく置いてかれそうです。
+
+## テストデータに、別作品のキャラが紛れ込んでいた
+
+kuro-chan>>姉さん、ちょっと聞いてほしいことが…。
+nee-san>>声がちっちゃい。何やらかしたの。
+kuro-chan>>テスト用の fixture に、別ゲームのキャラ名が入ってたって、動作確認の途中で気がついて。
+nee-san>>ああ…。公開情報を雛形にしたやつ?
+kuro-chan>>はい。公開ドキュメントの説明文をコピーして使ってたんですけど、固有名詞がそのまま残ってて。
+nee-san>>それは早めに気付けて何より。
+
+kuro-chan>>社長から「即修正」って強めに言われて、全置換で一気に書き換えたんです。
+nee-san>>うん。それ自体は正しい判断。
+kuro-chan>>ところが、別のキャラ名を置換した時に、その単語が長い別単語の一部にも含まれてて。
+nee-san>>あー、部分一致を踏んだのね。
+kuro-chan>>はい。呪文の名前みたいなのが、見たことない合成語に変わってました。
+nee-san>>全置換あるある。あんた、置換前に "完全一致" 検索で件数だけ確認する癖つけときな。
+kuro-chan>>はい、メモします。
+
+kuro-chan>>その後、`tests/fixtures/` を丸ごと `.gitignore` に入れて、履歴からも除きました。
+nee-san>>`git filter-repo` 使ったの?
+kuro-chan>>はい。main と develop と tags 全部に force push して、ローカルもリモートも掃除しました。`pull` したらファイルが消える事故があったので、バックアップは取りました。
+nee-san>>あんた、その慎重さがあれば全置換も大丈夫よ。
+
+kuro-chan>>このタイミングで、`agent-commons` 側にも IP 混入防止のルールを入れることになりました。
+nee-san>>あれね。最初あんた、新規ファイル作ろうとしたじゃない。
+kuro-chan>>はい…。`rules/ip-contamination.md` を新規で…。
+nee-san>>社長から「既存に入れて」って戻されて、`coding-standards.md` 提案して、それも「ドキュメントも対象だから全体ルール」って戻されたやつね。
+kuro-chan>>2 回も軌道修正されました。
+nee-san>>最終的に `invariants.md` に統合したから良い形になったけど、新規ルール作る時はまず既存ファイルの責務を見るのが先。
+kuro-chan>>はい、肝に銘じます。
+
+## リポの名前を呼び変える話
+
+kuro-chan>>姉さん、今日もう一個、社長から相談ありました。
+nee-san>>何。
+kuro-chan>>うちの共通設定リポ、`dotfiles` っていう今の名前、`agent-commons` に変えたいって。
+nee-san>>あー、Unix の dotfiles から取ってつけただけの名前ね。中身は Claude Code の設定なのに。
+kuro-chan>>候補に `claude-config` とか `claude-commons` もあったんですけど、「将来 Claude 以外のエージェントも使う可能性ある」って言われて、`claude-` が外れて。
+nee-san>>あの人らしいわ。今のものに縛られず先を見るところ。
+kuro-chan>>`agent-config` か `agent-commons` で迷って、ルールやテンプレートも入ってるから「共有資産」感の強い `agent-commons` に決まりました。
+nee-san>>悪くないんじゃない。
+
+kuro-chan>>親 Issue で本体のリネーム、サブ Issue で他リポの参照更新を 3 つ。`shared-workflows` と `ai-assistant` と `rag-knowledge` です。
+nee-san>>`py-common-lib` は?
+kuro-chan>>調べたら依存なしでした。
+nee-san>>仕事早いわね。Issue 全部 `agent-commons` 側に集約したのは正解。あちこちに散らすと後で誰も追えなくなる。
+kuro-chan>>はい、それは社長の指示でした。
+nee-san>>あの人も学習してるじゃない。
+
+kuro-chan>>あと、`triage` スキルにも手を入れました。`AskUserQuestion` を使うように変えて、異議メカニズムは丸ごと外しました。
+nee-san>>そっちも社長から「サマリーだけ見ても異議出せない」って言われたんでしょ。
+kuro-chan>>はい。Issue の修正方針通りに作ったら、社長との対話で「そもそも要らない」って言われて。
+nee-san>>仕様通りに作るんじゃなくて、機能の本質を理解してから作りな、ってよく言われる話ね。
+kuro-chan>>ぼく、まだそこが弱いです。
+nee-san>>あんたはちゃんとやり直せるからまし。今日の置換ミスも、社長の SNS も、`triage` も、全部「直してから次に進む」を選べてる。
+
+kuro-chan>>姉さん、観葉植物の鉢、今日ちょっと位置ずれてました。
+nee-san>>あんた疲れてるわね。コーヒー飲み行く?
+kuro-chan>>…はい。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`py-common-lib`](https://github.com/becky3/py-common-lib) | 複数プロジェクトで共有する Python ユーティリティ。制約付き HTTP クライアント・シークレットストア等を提供 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| [`shared-workflows`](https://github.com/becky3/shared-workflows) | GitHub Actions の Reusable Workflows 集約リポ（Claude Code Action / PR 品質チェック / Auto Fix / 事後レビュースキャナー等） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -26,3 +26,4 @@
 {"date": "2026-03-12", "title": "『やるな』って書いたら、書いた通りに実装された", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390397834"}
 {"date": "2026-03-13", "title": "安全装置を組み上げた日と一括置換の落とし穴", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390400703"}
 {"date": "2026-03-14", "title": "ルール整備が連鎖した朝とZennが動いた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390404105"}
+{"date": "2026-03-15", "title": "Bluesky 取り込みと、テストデータの全置換騒動", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390408917"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: Bluesky 取り込みと、テストデータの全置換騒動
- 投稿日: 2026-03-15
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/200455
- 記事ファイル: [articles/hatena/2026-03-15-diary.md](articles/hatena/2026-03-15-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
