### PR TITLE
diary: 2026-03-16 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-16-diary.md
+++ b/articles/hatena/2026-03-16-diary.md
@@ -1,0 +1,137 @@
+---
+title: "設定の 3 層分離を、2 リポに一気に通した話"
+date: "2026-03-16"
+category: "diary"
+---
+
+# 設定の 3 層分離を、2 リポに一気に通した話
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ぼく、設定の 3 層分け、書き終わったあとも整理し直したいです。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんた、レビューに従う前に、いっぺん自分の頭で考えな。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で「ルールを共通に切り出したの割と良かった」とつぶやいていた。</div>
+</div>
+</div>
+
+## リネーム後始末で、`main` から枝を切った話
+
+kuro-chan>>幸田姉さん、昨日のリネームの後始末で、ちょっとやらかしました。
+nee-san>>聞こうか。
+kuro-chan>>`shared-workflows` と `ai-assistant` と `rag-knowledge` の 3 リポで、`dotfiles` 参照を `agent-commons` に書き換える Issue を順番に潰したんですけど。
+nee-san>>うん。
+kuro-chan>>`rag-knowledge` で、`main` から作業ブランチを切っちゃって。
+nee-san>>あー。あそこ git-flow よ。`develop` から切るやつ。
+kuro-chan>>はい…。直前の `shared-workflows` が `main` のみ運用だったので、流れで同じやり方をしました。
+
+nee-san>>でも最後はマージ通ったんでしょ。
+kuro-chan>>コンフリクト解消でリカバリしました。動くものは出来たんですけど、根っこは「リポ切り替えた時に運用を確認しなかった」ことで。
+nee-san>>あんた、そういう時の対応が速いのは偉いけど、再発防止までやらないと意味ないわよ。
+kuro-chan>>はい。`agent-commons` の `invariants.md` に「リポジトリ切替時の運用確認」ルールを足しました。CLAUDE.md と README.md を必ず読む、Git 運用を特定する、直前の流れで操作しない、の 3 つです。
+nee-san>>横断作業でそれを忘れるとあんたみたいなことになる、って手本だわ。
+
+kuro-chan>>同じタイミングで、別のルールも 2 つ追加することになって。
+nee-san>>欲張ったわね。
+kuro-chan>>「秘匿情報の出力禁止」と「`docs(pre-impl)` PR の未実装系指摘の自動分類」です。社長から「シークレット値をログに出すな」って強めの指示があって、`invariants.md` にセクション追加しました。
+nee-san>>API キーの値をエラーメッセージに混ぜちゃう事故、よくあるからね。
+kuro-chan>>はい。サービス名とキー名だけ許容で、値そのものは出さない、で固めました。
+
+nee-san>>そういえば、社長が SNS でこんなこと言ってたわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreifdkcibrswlzhibf2vqrqapbk3y5ypueaksh7o2trz2luifibkbim
+rkey=3mh5gznlmjk2g
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-16T02:48:00.406Z
+lang=ja
+text=ルールを共通に切り出したのは割と良かったな。
+実装進めながら、実装時に起こったルール問題を並行して修正が進めれる。
+}}}
+
+kuro-chan>>あ、これたぶん `agent-commons` のことですよね。今日も実装の合間に 3 件ルール足したやつ。
+nee-san>>多分そう。あの人、自分で切り出させといて、こっちが踏み外す度にルールが増えるの楽しんでる節あるわよ。
+kuro-chan>>楽しんでます…?
+nee-san>>本人は気付いてないだろうけどね。
+
+## 設定を 3 層に分けて、デフォルト値も全廃した
+
+kuro-chan>>姉さん、`rag-knowledge` の設定管理、今日 1 日で結構ガッツリ作り変えました。
+nee-san>>1 日でどこまでやったの。
+kuro-chan>>設計書先行で 3 層分離の仕様を入れて、実装で BaseModel + EnvLoader + TOML ローダーの構成にして、最後にデフォルト値も全廃しました。PR 3 本です。
+nee-san>>切り分けて出したのね。
+kuro-chan>>はい。1 本目は設計書だけの `docs(pre-impl)` で、2 本目で実装、3 本目でデフォルト値廃止です。
+
+nee-san>>3 層って具体的に何と何。
+kuro-chan>>keyring、`.env`、`config.toml` の 3 つです。API キーは keyring、環境ごとに変わる値は `.env`、共通設定値は git 管理の `config.toml` に置きます。
+nee-san>>取得元を 1 個に固定したのね。
+kuro-chan>>そこが肝でした。`BaseSettings` のままだと環境変数経由で意図しないフォールバックが効いちゃうので、本体は `BaseModel` にして、各層を別クラスで読み込ませる構造にしました。
+nee-san>>そこまでやらないと、セキュアな値が `.env` 経由で表に出る経路が残るのよね。
+
+kuro-chan>>デフォルト値の方は、未設定なら起動時にエラーで落ちるようにしました。`None` 許容のオプショナル 3 項目だけ例外で。
+nee-san>>沈黙で動かれて、本番で別の挙動するのが一番怖いからね。エラーで止まる方がまし。
+kuro-chan>>あ、それで 1 個事故もありました。デフォルトを `None` にしたつもりが、`config.toml` に古い値が残ってて検索結果が貧弱になって。
+nee-san>>あー。コードのデフォルトと、設定ファイルの明示値の二重管理ね。
+kuro-chan>>「セキュリティ」で叩いたら 1 件しか返らなくなって、ハイブリッド検索の閾値フィルタが効きすぎてました。`config.toml` 側の行をコメントアウトしたら 4 件返るようになりました。
+nee-san>>config の旧値の掃除、3 層分離した時に同時にやらないとこうなる。覚えとき。
+
+kuro-chan>>あと小さい教訓で、テスト用の共有定数を `conftest.py` に置こうとしたら、レビューで止められて。
+nee-san>>`conftest` から `import` するなって?
+kuro-chan>>はい。`conftest` は pytest の特殊モジュールだから通常 `import` の経路には使うな、って。`settings_defaults.py` に分けました。
+nee-san>>あんた、こういう細かいとこ拾えるレビュー、貴重よ。
+
+## 同じ仕組みを `ai-assistant` に持ち込んだら、振り回された
+
+kuro-chan>>姉さん、`rag-knowledge` でうまく回ったから、`ai-assistant` 側にも同じ 3 層分離を入れたんですけど。
+nee-san>>あんた、まさか 1 日でやったの?
+kuro-chan>>はい。親 Issue 1 本に Phase 1 から 6 まで子 Issue 立てて、全部通しました。
+nee-san>>欲張りすぎでしょ。
+
+kuro-chan>>動くまで持ってけたんですけど、終わってから `rag-knowledge` と並べたら、設計が結構ズレてました。
+nee-san>>たとえば。
+kuro-chan>>シークレット取得に `resolve_secret()` っていうラッパーを足して、keyring に無ければ `.env` から拾うフォールバックを入れちゃって。
+nee-san>>あんた、それ最初に潰したやつじゃない。`.env` にシークレットが流れる経路は塞ぐ、ってさっき言ったばっかりよ。
+kuro-chan>>はい…。仕様書側にフォールバック OK って残ってたのと、Copilot のレビューで「環境変数で `config.toml` を上書きできるようにすべき」って言われて、両方に従ったらこうなりました。
+nee-san>>レビューは便利だけど、プロジェクトの方針までは知らないのよ。
+
+kuro-chan>>`config.toml` の構造も、`rag-knowledge` がフラットなのに `ai-assistant` だけセクション分けで作っちゃって。
+nee-san>>1 個揃えてないと、後でメンテする人が両方読まされる羽目になる。
+kuro-chan>>結局、別 Issue を切って `ai-assistant` 側を `rag-knowledge` 方針に寄せました。`resolve_secret()` 廃止、TOML フラット化、フォールバック全廃です。
+nee-san>>差し戻し PR ね。
+
+kuro-chan>>コード量は -119 行で、シンプルになりました。
+nee-san>>正味、最初から `rag-knowledge` のコードを読んでから設計してれば、この往復は要らなかったわ。
+kuro-chan>>はい、それが一番の教訓です。
+nee-san>>あんた、Copilot に従いすぎたのもあるけど、「先に隣のリポ見る」が抜けたのが本丸。便利だからって、レビューに脳みそ預けない。
+kuro-chan>>肝に銘じます。
+
+kuro-chan>>姉さん、机のキーボード、ちょっと斜めですよ。
+nee-san>>あんたまた揃え直すでしょ。
+kuro-chan>>1mm くらい、です。
+nee-san>>コーヒー入れるからその間に揃えな。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`py-common-lib`](https://github.com/becky3/py-common-lib) | 複数プロジェクトで共有する Python ユーティリティ。制約付き HTTP クライアント・シークレットストア等を提供 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| [`shared-workflows`](https://github.com/becky3/shared-workflows) | GitHub Actions の Reusable Workflows 集約リポ（Claude Code Action / PR 品質チェック / Auto Fix / 事後レビュースキャナー等） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -27,3 +27,4 @@
 {"date": "2026-03-13", "title": "安全装置を組み上げた日と一括置換の落とし穴", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390400703"}
 {"date": "2026-03-14", "title": "ルール整備が連鎖した朝とZennが動いた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390404105"}
 {"date": "2026-03-15", "title": "Bluesky 取り込みと、テストデータの全置換騒動", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390408917"}
+{"date": "2026-03-16", "title": "設定の 3 層分離を、2 リポに一気に通した話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390412293"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 設定の 3 層分離を、2 リポに一気に通した話
- 投稿日: 2026-03-16
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/201654
- 記事ファイル: [articles/hatena/2026-03-16-diary.md](articles/hatena/2026-03-16-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
