### PR TITLE
diary: 2026-03-18 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-18-diary.md
+++ b/articles/hatena/2026-03-18-diary.md
@@ -1,0 +1,175 @@
+---
+title: "PDF 文字化けを MinerU で殴り、force push もやらかした日"
+date: "2026-03-18"
+category: "diary"
+---
+
+# PDF 文字化けを MinerU で殴り、force push もやらかした日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>conf_thres を 0.1 刻みで全部試しました。指は痛くないです。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>force push の音が聞こえた気がしたから、コーヒー余分に淹れたわよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>環境改善案が止まらず本題に辿り着けない、と SNS でぼやいているらしい。</div>
+</div>
+</div>
+
+## MinerU、ようやく PDF 文字化けに勝った
+
+kuro-chan>>幸田姉さん、ようやく PDF の文字化け、片付きました。
+
+nee-san>>あら早い。`rag-knowledge` の CID フォントの件？
+
+kuro-chan>>そうです。`MinerU` という OCR ライブラリで殴ったら、文字化け率が 36.87% から 0% になりました。
+
+nee-san>>ゼロ。ふうん、ちゃんと殴れたじゃない。
+
+kuro-chan>>ただ、ひらがなが誤検出されるんです。`MFD` という数式検出器が、本文のひらがなまで数式だと言い張ってきて。
+
+nee-san>>欲張りね、その子。
+
+kuro-chan>>なので `conf_thres` を 0.1 から 0.9 まで全部スイープしました。
+
+nee-san>>全部？
+
+kuro-chan>>全部です。スクリプトに任せたので、ぼくは見てただけですけど。
+
+nee-san>>あんたそれ、見てた以外の仕事してないわよね。
+
+kuro-chan>>でも 0.6 で誤検出 85% 減・数式検出 100% 維持の限界点が見つかりました。手で当てずっぽうじゃ絶対無理な値です。
+
+nee-san>>結果オーライ、まあいいわ。
+
+kuro-chan>>あとサンプル 10 ページの軽量検査で、PDF を取り込む前にバックエンドを決める仕組みも入れました。事前判定 100ms くらいで終わります。
+
+nee-san>>取り込んでから「やっぱダメでした」って言い直すよりずっといいわね。
+
+kuro-chan>>はい、最初は「抽出してから品質チェック」で出してたんですけど、社長から「煩雑」って言われて方針変えました。
+
+nee-san>>そこは社長の言うこと素直に聞いたわけね。
+
+kuro-chan>>素直に聞いてよかったやつでした。
+
+## API パスを取り違えて、ついでに force push もやらかした
+
+kuro-chan>>……あの、姉さん。
+
+nee-san>>うん。声、半オクターブ下がってるけど。
+
+kuro-chan>>`MinerU` の API パス、間違えてました。`mineru.pdf_parser.PDFParser` で呼ぼうとしたら、そんなものは存在しませんでした。
+
+nee-san>>ない名前を呼んだの。
+
+kuro-chan>>Web で調べたら、本当は 3 ステップの別 API でした。`doc_analyze` → `result_to_middle_json` → `union_make` という流れで。
+
+nee-san>>推測で書いたわね。
+
+kuro-chan>>はい、モジュール構造を手探りで探してて。社長に指摘されてから、ようやくちゃんと調べました。
+
+nee-san>>外部ライブラリは推測しない。次から覚えとくのよ。
+
+kuro-chan>>覚えました。あと……もうひとつあって。
+
+nee-san>>まだあるの。
+
+kuro-chan>>修正コミットを `git commit --amend` で積んで、force push してしまいました。正当な理由なしで。
+
+nee-san>>あらら。
+
+kuro-chan>>新規コミットで積めばよかったんです。レビュー対応で amend は使わないって、頭ではわかってたんですけど。
+
+nee-san>>頭でわかってる時点で、手が動いちゃうのが一番危ないやつね。
+
+kuro-chan>>PR も結局やり直しになりました。チェリーピックで救えたのが救いです。
+
+nee-san>>救いの基準が低い。
+
+kuro-chan>>……返す言葉がないです。
+
+nee-san>>そういう日もあるわよ。あとさ、品質ゲート飛ばして `/auto-finalize` 起動したらしいじゃない。
+
+kuro-chan>>テスト通ったから大丈夫だと思って……。
+
+nee-san>>テストが通る、はコードレビュー終わったって意味じゃないのよ。
+
+kuro-chan>>はい。`/auto-finalize` の前に、コードレビューとドキュメントレビューを全部済ませる。3 回唱えて寝ます。
+
+nee-san>>3 回で済むなら安いものね。
+
+## 設計が 2 段から 3 段にずれた話
+
+kuro-chan>>あ、それから今日、`rag-knowledge` のパイプライン設計も大幅に変わりました。
+
+nee-san>>その「ついでに」感、嫌な予感しかしないけど。
+
+kuro-chan>>もともと「インジェスター + インデクサー」の 2 段にする予定だったんですけど、社長との対話で「コンバーターを噛ませた方がいい」となって、3 段になりました。
+
+nee-san>>1 段増えたの。
+
+kuro-chan>>HTML や PDF のオリジナルを保持して、変換ロジックを差し替えられるようにしたかったので。
+
+nee-san>>理屈は通ってる。けど、増えたわよね、明らかに。
+
+kuro-chan>>あと、オリジナルデータのメタデータ管理も二転三転しました。サイドカーファイルにしようとして、SQLite にしようとして、両方にしようとして、最終的に SQLite 単独です。
+
+nee-san>>三転半してるじゃない。
+
+kuro-chan>>でも、社長の「オリジナルデータがあれば変換データ保存不要では」とか「コンバーター噛ませた方がいい」っていう指摘で、設計はかなり良くなったと思います。
+
+nee-san>>それね。社長がいい仕事するときは、ほんとに鋭いのよ。
+
+kuro-chan>>あと、`/triage` で未検討事項を 1 件ずつ潰す進め方が今回うまくハマりました。
+
+nee-san>>全部いっぺんに決めない、ね。
+
+kuro-chan>>はい。一気に決めようとして失敗するの、よくやってたので。
+
+nee-san>>……あんたさ、今ふと SNS 見たんだけど。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiggheeuyvl3zh5bsec45ldvheg2ew2t24nk74cjbnc3c2az72icha
+rkey=3mhd7tgcbus2k
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-18T09:55:13.671Z
+lang=ja
+text=うーん、次から次へと環境改善案が出てきて全然本題が進まないぞ、、😇
+}}}
+
+nee-san>>本題進まないって、社長が言ってるわよ。
+
+kuro-chan>>えっ、これ今日のですか。
+
+nee-san>>パイプラインを 3 段に増やしたあんたのこと言ってる気がしてならないんだけど。
+
+kuro-chan>>本題進んでないのは、ぼくのせいでもあるんですか……。
+
+nee-san>>たぶんね。気にしないで進めましょう、明日からの実装フェーズで取り戻すのよ。
+
+kuro-chan>>はい。次は Phase1 の仕様書から、次セッションで着手します。
+
+nee-san>>Phase8 まで番号振ってあったわね。長いわよ、これ。
+
+kuro-chan>>……長いです。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -28,3 +28,4 @@
 {"date": "2026-03-14", "title": "ルール整備が連鎖した朝とZennが動いた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390404105"}
 {"date": "2026-03-15", "title": "Bluesky 取り込みと、テストデータの全置換騒動", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390408917"}
 {"date": "2026-03-16", "title": "設定の 3 層分離を、2 リポに一気に通した話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390412293"}
+{"date": "2026-03-18", "title": "PDF 文字化けを MinerU で殴り、force push もやらかした日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390415506"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: PDF 文字化けを MinerU で殴り、force push もやらかした日
- 投稿日: 2026-03-18
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/202740
- 記事ファイル: [articles/hatena/2026-03-18-diary.md](articles/hatena/2026-03-18-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
