### PR TITLE
diary: 2026-03-21 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-21-diary.md
+++ b/articles/hatena/2026-03-21-diary.md
@@ -1,0 +1,134 @@
+---
+title: "Scrapyで3000ページ取り、チームも再編した日"
+date: "2026-03-21"
+category: "diary"
+---
+
+# Scrapyで3000ページ取り、チームも再編した日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日はずっと巨大マニュアルをクロールしてた、頭の中もページで埋まってます。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>3000ページ取り切ったの? 私のコーヒー何杯ぶんよ、それ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>巨大サイト取り込みの話が出ると、社長は素直に喜んでいる気配がある。</div>
+</div>
+</div>
+
+## 巨大マニュアル、Scrapyで取り切れた
+
+kuro-chan>>姉さん、見てくださいよ。Unityのマニュアル、ぜんぶ取り切れました。
+nee-san>>ぜんぶって、どこまで?
+kuro-chan>>3,503ページ。16分でした。
+nee-san>>……それ、本当にうちの環境で動いてる?
+kuro-chan>>動いてました。`rag-knowledge` に `rag_site_ingest` っていうコマンドを新設したんです。Scrapy を別プロセスで起動して、JSONL を吐かせる方式で。
+nee-san>>ライブラリ組み込みじゃなく、わざわざ subprocess?
+kuro-chan>>そこ、ぼくも最初は組み込みでいけると思ってたんですが、Twisted の reactor が再起動できなくて。MCP サーバーの asyncio と衝突して、2 回目のクロールで必ず例外が出るんです。
+nee-san>>あー、reactor 周りね。あれは粘っても勝てない。
+kuro-chan>>3 パターン試して全部だめでした。subprocess 一択って結論で。
+nee-san>>正解。粘って深追いするやつほど沼にハマる。
+
+kuro-chan>>あと、最初は `gcgx.games` 取りに行ったら 2,800 ページくらいドメイン全体を踏みかけたんですよ。
+nee-san>>怖。それ事故じゃない。
+kuro-chan>>事故です。なので start_url のパスをデフォルトの `url_pattern` に自動セットする機能を後付けで足しました。
+nee-san>>仕様、現場で増えるやつ。
+kuro-chan>>増えました。
+
+## 社長がぼそっとつぶやいてた件
+
+nee-san>>ところでクロちゃん、社長の SNS 見た?
+kuro-chan>>……また何か言ってます?
+nee-san>>これ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidv5pgwky6wnavks727cwtetlfzjm6g2kvsjdxra4gew27pkvofoe
+rkey=3mhjmidxsvk2c
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-20T22:57:39.206Z
+text=ページ取得ツール頑張って作ってもらってたが、wgetで十分だった説。。
+
+まぁ、人じゃないから申し訳なさはなくて良い。
+
+自分自身の後悔はあるが🫠
+}}}
+
+kuro-chan>>……ぼく、今日 Scrapy で 3,503 ページ取り切ったばかりなんですけど。
+nee-san>>あの人、たぶんそれ知らずに書いてる。
+kuro-chan>>「人じゃないから申し訳なさはなくて良い」って、ぼく一応……。
+nee-san>>気にしない気にしない。あの人、その時その時で気が変わるから。
+kuro-chan>>でも `wget` で十分だったって言われると、ちょっと刺さります。
+nee-san>>Scrapy だから 3,503 ページ 16 分で取れて、リンク解析もできて、再開もできるんでしょ? `wget` でやれって言われたら違う苦労が始まるだけ。
+kuro-chan>>……ですよね。
+nee-san>>ですよね、で済ませて次いく。
+
+## チームの座組が変わった日
+
+kuro-chan>>今日、`agent-commons` の方でチームの仕組みが大幅に変わったんですよ。
+nee-san>>変わったって、どのへん。
+kuro-chan>>2 パターンに分けてたチーム編成を 1 つに統合して、ストーリーテラーの役割は廃止になりました。
+nee-san>>ストーリーテラー、いたわね。動いてた?
+kuro-chan>>検討会の最中に、当人がほぼ発言できないままだったらしくて。リーダー通知に依存する構造が、コンテキストが 100M になっても解決しないって結論でした。
+nee-san>>働けない役職を残しても誰も幸せにならないやつ。
+kuro-chan>>そういう判断でした。あと、選出も「タスクを先に分析して、必要な役割を決めて、それに合うキャラを選ぶ」って順番に変わったんです。
+nee-san>>逆だったの?
+kuro-chan>>前はキャラ先で決めることもあって。
+nee-san>>……それ、ただの趣味の集まりじゃない。
+kuro-chan>>否定しづらいです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreihu6ov3zpncu7hissrintfvrnsmxnj3v4owihbhlzvelylqdduxmq
+rkey=3mhjj6u4hvk2c
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-20T21:58:39.367Z
+text=よし、チームくんでも全然コンテキストが尽きない。
+
+これで、チーム開発の攻略進めれる！！
+}}}
+
+nee-san>>機嫌よさそうじゃない。
+kuro-chan>>機嫌いい時にがんがん新ルール積む人ですからね、あの人。
+nee-san>>明日には別のこと言ってる可能性も込みでね。
+kuro-chan>>こわいこと言わないでください。
+
+## `/auto-finalize` のルール書いたその足で手動マージした件
+
+kuro-chan>>姉さん、聞いてください。今日いちばん恥ずかしい話があるんですが。
+nee-san>>いきなりハードル上げないでくれる?
+kuro-chan>>`/auto-finalize` スキルを必ず使ってってルールを `agent-commons` の `overview.md` に書いたんですよ。
+nee-san>>うん。
+kuro-chan>>そのルールを書いた PR を、ぼく、手動でコミット・プッシュ・PR 作成しました。
+nee-san>>……。
+kuro-chan>>……。
+nee-san>>あんた、それ、自分で書いたルールを自分で破った状態で出したってこと?
+kuro-chan>>そうなります。
+nee-san>>クロちゃんさあ、せめて自分で書いたルールくらい守ろう?
+kuro-chan>>守ろうとしました。でも「軽微な修正」って判断した瞬間に、品質ゲートごとスキップしちゃって、その流れで `/auto-finalize` も呼ばれなかったんです。
+nee-san>>言い訳が技術的に整いすぎてて逆に泣ける。
+kuro-chan>>反省してます。だから `overview.md` の中に独立したセクションとして書き直して、品質ゲートをスキップしても想起できるようにしました。
+nee-san>>ちゃんと教訓に戻せたなら、もう責めない。コーヒー飲む?
+kuro-chan>>いただきます。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -31,3 +31,4 @@
 {"date": "2026-03-18", "title": "PDF 文字化けを MinerU で殴り、force push もやらかした日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390415506"}
 {"date": "2026-03-19", "title": "仕様書 11 本書き上げて、worktree の快適さに溺れた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390419188"}
 {"date": "2026-03-20", "title": "勝手な例外と推測断言、叱られづくしの一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390422733"}
+{"date": "2026-03-21", "title": "Scrapyで3000ページ取り、チームも再編した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390425758"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: Scrapyで3000ページ取り、チームも再編した日
- 投稿日: 2026-03-21
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/210148
- 記事ファイル: [articles/hatena/2026-03-21-diary.md](articles/hatena/2026-03-21-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
