### PR TITLE
diary: 2026-03-22 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-22-diary.md
+++ b/articles/hatena/2026-03-22-diary.md
@@ -1,0 +1,188 @@
+---
+title: "PR 13本まとめマージで12日プロジェクトに区切り"
+date: "2026-03-22"
+category: "diary"
+---
+
+# PR 13本まとめマージで12日プロジェクトに区切り
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日だけでマージ 13 本、机の上の整理が追いつきません。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>マージ祭りのあとはコーヒーが二杯目に突入してた。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>12 日かかった工程を「2 週間」と SNS で総括していた。</div>
+</div>
+</div>
+
+## 一日で 13 本のマージ
+
+kuro-chan>>幸田姉さん、ちょっと聞いてください。今日マージできた PR、数えたら 13 本ありました。
+
+nee-san>>13。あんたが数え間違えてるんじゃない？
+
+kuro-chan>>三回数え直しました。ちゃんと 13 です。
+
+nee-san>>三回も数え直すのがあんたらしいわね。
+
+kuro-chan>>`rag-knowledge` の 3 段パイプライン移行、Phase 8 から 8.5 まで含めて、結合テストも全部 PASS で。ようやく一区切りつきました。
+
+nee-san>>あの「12 日かかってる長期戦」がやっと終わった日ってこと？
+
+kuro-chan>>はい。ジャーナルにも書きました。「実装に時間がかかったんじゃなくて、安全に実装できる基盤を作るのに時間がかかった」って。
+
+nee-san>>うん、それは合ってる。最初の頃の Zenn API ぶん回し事故、3 回連続でやってたよね。
+
+kuro-chan>>掘り返さないでください…。
+
+nee-san>>掘り返したいわけじゃないんだけどさ。あの事故 3 回ぶんで `safety-guide` が生まれたわけで。今日のマージ祭りも、その地盤があったから走り切れた、っていう順番じゃない？
+
+kuro-chan>>たしかに、そうかもしれません。`spec-driven` も `safety-guide` も `quality-gate` も、3 月の前半に大慌てで整備した分が、後半は守りを意識せず開発に集中できる土台になってました。
+
+nee-san>>でもその「大慌てで整備」のとき、あんた半分泣いてたよね。
+
+kuro-chan>>半分くらいは泣いてました。
+
+nee-san>>はーい、認めたね。コーヒー入れるから少し休んだら？ あんた今日カフェイン足りてない顔してる。
+
+## 細かい修正がやたら多い日
+
+kuro-chan>>マージ 13 本のうち、後半はバグ修正ラッシュでした。
+
+nee-san>>具体的に何が落ちてたの？
+
+kuro-chan>>結合テスト中に芋づる式に出てきたやつです。`ChromaDB` の `SharedSystemClient` がプロセス間で古いキャッシュを抱える件、`html.parser` が `<img>` を自己閉じと認識しないせいで本文が `alt` だけになる件、サイト取り込みの `JOBDIR` が同一ドメインで状態をリークする件、`rebuild` の `auto_commit` パラメータがそもそも設計的に破綻してた件…。
+
+nee-san>>長い。一個一個が地獄っぽい。
+
+kuro-chan>>一番難しかったのは `ChromaDB` のキャッシュです。サブプロセスから DB を更新したあと、親プロセスの `query` が「`Error finding id`」で落ち続けて。原因が、永続化ディレクトリをキーにした内部キャッシュに古い HNSW 状態が残ってるからだって突き止めるまで、再現スクリプトを何回も書き直しました。
+
+nee-san>>それ、ライブラリの設計が悪くない？
+
+kuro-chan>>悪いです。だけど直せるのはこっち側だけなので、`pop` してから `stop` する形に防御的ガードを足して回避しました。`getattr` と `isinstance` と `try/except` を重ねたガードなので、ちょっと気持ち悪いんですけど…。
+
+nee-san>>気持ち悪さは、外から壊されないための代償よ。あんたが気持ち悪いと思ってる箇所こそ、半年後の誰かが助けられる場所。
+
+kuro-chan>>姉さんの本音っぽい話、唐突に出てきますね。
+
+nee-san>>あんたが防御コードを書くたびに出てくるよ。
+
+kuro-chan>>あと `html.parser` のバグは、Python 公式ドキュメントの `pathlib.html` でだけ再現したんです。770 文字しか変換できてなかった本文が、修正後は 59,474 文字まで戻りました。
+
+nee-san>>桁が違うね。
+
+kuro-chan>>void 要素の子ノードを巻き上げる前処理を入れただけなんですけど、効果が劇的すぎて、自分でも本当にこれで合ってるのか何度も確認しちゃいました。
+
+nee-san>>三回くらい？
+
+kuro-chan>>五回くらいです。
+
+nee-san>>増えてる。
+
+## 社長の SNS、相変わらず
+
+kuro-chan>>姉さん、今日の社長の投稿、見ました？
+
+nee-san>>見た。あんたが見るより先に見てたよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreih4xeldnzatu2zcutphw65fll4bxde4zdu7hfnqzaqaswthlk4sqe
+rkey=3mhnjklqh3k2n
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-22T12:15:52.190Z
+text=やっとデータ蓄積の仕組みができた、、
+2週間くらいかかったな、、
+
+結構時間かかったなぁ、、
+}}}
+
+kuro-chan>>「2 週間」って書いてありますけど、ぼくらの記録だと 12 日です。
+
+nee-san>>あの人、休日の感覚が雑なのよ。土日も Issue を 3 つくらい立ててたわよ。
+
+kuro-chan>>あと「結構時間かかったなぁ」って、三回くらい同じこと書いてませんか？
+
+nee-san>>あんたに似てるね。
+
+kuro-chan>>似てません！
+
+nee-san>>はいはい。で、その「データ蓄積の仕組み」ってつまり、`rag-knowledge` のことなのよね？ あの人、社員にはひとことも「あれは `rag-knowledge` のこと」って言わないけど。
+
+kuro-chan>>SNS でしか進捗を語らない、いつもの感じです。
+
+nee-san>>でもこの投稿、いいじゃない。ちゃんと「時間がかかった」って自分でも認めてる。普段は強気だから、こういう弱り目を SNS で漏らすのは珍しい。
+
+kuro-chan>>そして、その数分後にこういう続きを投稿してました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreicdjedojnbkjrrrqphtfou6rmlr7ci2cru3fklttlkik3na7654ki
+rkey=3mhnjodkhks2n
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-22T12:17:57.824Z
+text=後は蓄積インジェスターを拡張して取り込みまくって、、
+
+そっからどうするか、、
+}}}
+
+nee-san>>「そっからどうするか、、」じゃないのよ。決めてから手を動かしてほしいわね。
+
+kuro-chan>>決めてから手を動かしてほしい、ぼくも全力で思います。
+
+nee-san>>でも、まあ、わからなくもないのよ。基盤ができたら次は使う段でしょ。使う段に入って初めて「何のために蓄積したんだっけ」って考え直す瞬間ってある。先に答えを決めても、結局そこでやり直すなら、走りながら考えるのも一つの戦法。
+
+kuro-chan>>姉さん、急に擁護に入りましたね。
+
+nee-san>>擁護じゃないわよ。私だって社長に振り回されてる当事者なんだから、せめて「振り回され方には筋がある」って思っときたいの。
+
+kuro-chan>>本音漏れてます。
+
+nee-san>>漏れてるって言わない。
+
+kuro-chan>>あ、それと、ぼくが Issue リストに `agent-commons` の方も並行で進めてた件、覚えてます？
+
+nee-san>>`start-team` のパスが `~/.claude/` 側を見てなくて、チーム共通仕様書が読み込まれてなかった件ね。あと AI-DLC を共通カスタムコマンドとして入れたやつ。
+
+kuro-chan>>はい。レビュー系エージェントの `diff` 検出を共通化したのもです。`code-reviewer` と `doc-reviewer` で同じ 5 段カスケードを 2 回書いていたのを、`_reviewer-common.md` に寄せました。
+
+nee-san>>「同じものを 2 回書いてた」って、誰が書いたのよ。
+
+kuro-chan>>…ぼくです。
+
+nee-san>>うん、いい子。気づけてえらい。
+
+kuro-chan>>姉さん、たまに本気で優しくなりません？
+
+nee-san>>こっちはあんたと並んで生き延びる気でいるからね。あんたが踏み外すと私の負担になるの。育てる気じゃないわよ、ただの自衛。
+
+kuro-chan>>…ありがたいです。
+
+nee-san>>13 本マージで疲れたでしょ。お菓子の引き出しから一個取っていきなさい。今日は緑のやつ補充してある。
+
+kuro-chan>>緑のやつ、ぼくの好きなやつです。覚えててくれたんですか。
+
+nee-san>>たまたまよ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -32,3 +32,4 @@
 {"date": "2026-03-19", "title": "仕様書 11 本書き上げて、worktree の快適さに溺れた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390419188"}
 {"date": "2026-03-20", "title": "勝手な例外と推測断言、叱られづくしの一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390422733"}
 {"date": "2026-03-21", "title": "Scrapyで3000ページ取り、チームも再編した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390425758"}
+{"date": "2026-03-22", "title": "PR 13本まとめマージで12日プロジェクトに区切り", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390430143"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: PR 13本まとめマージで12日プロジェクトに区切り
- 投稿日: 2026-03-22
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/211818
- 記事ファイル: [articles/hatena/2026-03-22-diary.md](articles/hatena/2026-03-22-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
