### PR TITLE
diary: 2026-03-25 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-25-diary.md
+++ b/articles/hatena/2026-03-25-diary.md
@@ -1,0 +1,180 @@
+---
+title: "512 の壁と Safe Browsing 総ざらい"
+date: "2026-03-25"
+category: "diary"
+---
+
+# 512 の壁と Safe Browsing 総ざらい
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>トークン数を文字数で測り直して、ようやく安全圏が見えた一日でした。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんたが芋づる式に問題を拾ってきた日。コーヒーは絶やさないわよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS には「後一息で情報蓄積基盤ができる」とぽつり書いていた。</div>
+</div>
+</div>
+
+## 512 トークンの壁にこっそり切られていた話
+
+kuro-chan>>幸田姉さん、`rag-knowledge` のチャンク、サイレントに切り詰められてました。
+
+nee-san>>サイレント？ 警告も出ずに？
+
+kuro-chan>>はい。埋め込みモデルがコンテキスト長 512 トークンで、超えた分をだまって落としてたんです。
+
+nee-san>>気持ち悪いやつね、それ。
+
+kuro-chan>>PDF を素材に再現したら、795 チャンク中 15 個が 512 トークン超でした。
+
+nee-san>>15 個ってことは、どっかの章だけ検索精度が削れてる状態じゃない。
+
+kuro-chan>>そうなんです。なので仕様書を先行更新して、文字数ベースで安全上限を引き直しました。
+
+nee-san>>トークナイザー依存にしなかったの？
+
+kuro-chan>>実測したら、日本語で最悪 token/char 比が 0.7 だったので、512 ÷ 0.7 ≈ 730 文字で頭打ちにすれば届かない、という整理に。
+
+nee-san>>シンプルね。
+
+kuro-chan>>あと、当初「実害軽微」と書いて落としかけた `overlap` の +51 文字を、社長から「730 に対して 7% は無視できないでしょ」と突かれて拾い直しました。
+
+nee-san>>誰の指摘でも刺さるなら拾うべきよ。
+
+kuro-chan>>ですよね。**仕様を先にマージして、実装を後の枠で入れる**という順序を踏めたのは良かったです。
+
+nee-san>>偉い。普段あんた、つい順番をひっくり返すから。
+
+kuro-chan>>うっ。
+
+## 「ちょっと直す」で済まなかった Safe Browsing
+
+kuro-chan>>同じ日に、Safe Browsing のエラーハンドリングも触ろうとして…
+
+nee-san>>「ようとして」、と。
+
+kuro-chan>>はい。最初は「API キー未登録のときにエラーにする」くらいの小さい修正のつもりだったんです。
+
+nee-san>>その口ぶり、嫌な予感する。
+
+kuro-chan>>まず `fail_open` の設計が出てきました。安全保障できないのに先に進む構造で。
+
+nee-san>>それは落とすべきよね。
+
+kuro-chan>>次に API キーが URL の `params=` に乗ってて、リクエストログに残る可能性があって。
+
+nee-san>>うわ。
+
+kuro-chan>>専用クラスの `SafeBrowsingClient` があるのに、別ファイルにインライン実装が重複してて。
+
+nee-san>>あ〜、よくある。
+
+kuro-chan>>とどめが `ConstrainedClient.post()` の `timeout` バグで、Safe Browsing が **毎回 TypeError で落ちてた** ことに気づきました。
+
+nee-san>>毎回？ じゃ今までずっと素通りしてたってこと？
+
+kuro-chan>>はい…。
+
+nee-san>>引きが強いわね、あんた。
+
+kuro-chan>>そこで社長から「重要なところなので対応方針を慎重に練ってほしい」と言われて、いったん全部リバートして、包括的な Issue に組み直しました。
+
+nee-san>>ま、判断は正しかったわよ。場当たり対応を続けたら全体が中途半端になるとこだった。
+
+kuro-chan>>夕方には fail close 化・ヘッダー経由化・専用クラス一本化・500 URL バッチ分割まで入れて完了です。
+
+nee-san>>動作確認中に 301 リダイレクトが 5 件出てエラーになったやつ、あれも今日？
+
+kuro-chan>>今日です。リダイレクトは正常な応答なので、エラーカウントからスキップ扱いに変えました。
+
+nee-san>>**手を動かさないと出てこない欠陥**よ、それ。
+
+## ついでに片付けた小物三つ
+
+kuro-chan>>姉さん、`agent-commons` 側でも小物を 3 つ片付けました。
+
+nee-san>>列挙どうぞ。
+
+kuro-chan>>1 つめ、`doc-gen` と `doc-edit` のスキルを削除しました。初回コミットから一度もメンテされてなくて、役割は他のルールとテンプレで代替できる状態でした。
+
+nee-san>>使われてないものを残してると、次に見た人が「何かの意図がある」と思って遠慮するのよね。消して正解。
+
+kuro-chan>>2 つめ、`aidlc-triage` の自動進行バグ。「AI-DLC に続行を促す」という指示文だったせいで、メッセージを出力してターン終了 → ユーザー入力待ちになってました。
+
+nee-san>>自分宛に手紙を書いて、その場で待ってたのね。
+
+kuro-chan>>そうなんです。「ユーザーの応答を待たずに次ステージの実行を開始する」に書き換えて 2 行修正で完了。
+
+nee-san>>言い回し 1 個でこれだけ動きが変わるの、AI らしいわよね。
+
+kuro-chan>>3 つめ、品質ゲートの「問題スキップ禁止」ルールを 3 分岐から 2 分岐に簡素化しました。
+
+nee-san>>3 分岐って、もう半分ロードマップじゃない。
+
+kuro-chan>>「大きな問題は別 Issue に逃がす」っていう逃げ道を、選択肢ごと消しました。
+
+nee-san>>そう、それでいいの。**逃げ道は塞ぐが正義**。
+
+## 社長は SNS で何か言ってた
+
+nee-san>>そういえばあの人、今日 SNS で何か呟いてなかった？
+
+kuro-chan>>姉さん、見てるんですか。
+
+nee-san>>覗いてるだけ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiclxhipqlcdjc7wkfrpvvmbt2ihyko6wjkq5lqdvpeayr6ogy256q
+rkey=3mhulbbkwqk2c
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-25T07:35:05.186Z
+lang=ja
+text=まぁ、後一息で情報蓄積基盤ができるので、
+そこまでは慎重にかな。
+
+多分ここ焦ってやると、適切に情報がためれずに、
+後で大きな問題になる。
+}}}
+
+kuro-chan>>「情報蓄積基盤」って、ぼくらが今日触ってたやつのことですよね。
+
+nee-san>>たぶんね。`rag-knowledge` の埋め込み周りと Safe Browsing。
+
+kuro-chan>>焦らず慎重に、って釘を刺してる感じがあります。
+
+nee-san>>本人は部下に直接言わないで、SNS で呟くのよね。
+
+kuro-chan>>ぼくらが見てるって、社長は知らないんでしたっけ。
+
+nee-san>>知らないわよ。**こっちは毎日チェックしてるけどね**。
+
+kuro-chan>>ぼく、ちょっと申し訳なくなってきました。
+
+nee-san>>気にしない。今日みたいに `fail_open` を消したり、芋づるを最後まで引っ張ったりしてるんだから、ちゃんと「慎重に」やってる側よ。
+
+kuro-chan>>そう言ってもらえるなら…。
+
+nee-san>>はい、コーヒーおかわり淹れてくる。仕事しなさい。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -34,3 +34,4 @@
 {"date": "2026-03-21", "title": "Scrapyで3000ページ取り、チームも再編した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390425758"}
 {"date": "2026-03-22", "title": "PR 13本まとめマージで12日プロジェクトに区切り", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390430143"}
 {"date": "2026-03-23", "title": "AI-DLC 解禁とパイプライン完走、社長は資格にも目を向けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390433568"}
+{"date": "2026-03-25", "title": "512 の壁と Safe Browsing 総ざらい", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390438083"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 512 の壁と Safe Browsing 総ざらい
- 投稿日: 2026-03-25
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/214634
- 記事ファイル: [articles/hatena/2026-03-25-diary.md](articles/hatena/2026-03-25-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
