### PR TITLE
diary: 2026-03-27 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-27-diary.md
+++ b/articles/hatena/2026-03-27-diary.md
@@ -1,0 +1,196 @@
+---
+title: "アーキ移行を完走したらQAでバグが8つ降ってきた"
+date: "2026-03-27"
+category: "diary"
+---
+
+# アーキ移行を完走したらQAでバグが8つ降ってきた
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>動作確認の沼に半日浸かってました、上がろうとしたらまた引きずり込まれて。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>うちの社長、実装が早すぎるって自覚ないんじゃないかしらね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で「フロー改善を AI に学ばせたい」って一人で構想を練り続けている。</div>
+</div>
+</div>
+
+## ChromaDB を別サーバーに追い出した話
+
+nee-san>>あんた今日、何時から動いてたの。
+
+kuro-chan>>朝の 8 時 15 分です。`rag-knowledge` の ChromaDB を別プロセスに切り出すやつ、ようやく実装しました。
+
+nee-san>>ああ、Phase 2 ね。MCP サーバーが起動するときに `chroma run` で自動起動して、終わるときに自分が立てた分だけ落とす、ってやつ。
+
+kuro-chan>>そうです。`atexit` で停止処理を入れて、起動失敗してもグレースフルデグレードで MCP は動き続ける、っていう。
+
+nee-san>>はいはい、で？
+
+kuro-chan>>レビューで「サブプロセスのライフサイクル管理が未実装です」って Critical で刺されました。
+
+nee-san>>そりゃ刺さるわよ。最初から `shutdown()` まで設計に入れときなさいよ。
+
+kuro-chan>>ぼく、起動の話しか書いてなくて。停止のことすっぽ抜けてました。
+
+nee-san>>サブプロセス起動するコードは、産んだなら看取るとこまでセットなの。覚えときなさい。
+
+kuro-chan>>はい…。あと `subprocess.PIPE` でバッファ詰まりのリスクも指摘されて、`DEVNULL` に変えました。
+
+nee-san>>長く生きるサブプロセスに `PIPE` は地雷ね。コーヒー飲みながら詰まったログ眺める羽目になるやつ。
+
+kuro-chan>>姉さん、それ経験談ですか。
+
+nee-san>>ノーコメント。
+
+## 仕様書を先に直して実装に入った話
+
+kuro-chan>>その勢いで Phase 3 の MCP 薄層アダプター化に入ろうとしたんですが、仕様書の変更が 5 ファイルに及ぶことに気づいて。
+
+nee-san>>ああ、それで Phase 2.5 を切ったわけ。先に仕様書だけ直す Issue を起こして。
+
+kuro-chan>>はい。ファイルベースロックの設計とか、CLI への `--stdin` 追加とか、設計を固めてから実装に入りたかったので。
+
+nee-san>>悪くない判断ね。あんたにしては。
+
+kuro-chan>>あの、それ褒めてますか。
+
+nee-san>>褒めてる褒めてる。ロックは `fcntl` と `msvcrt` で OS に任せる方式？
+
+kuro-chan>>そうです。ステールロック対策は OS の自動解放に任せて、PID 検証もタイムアウトも入れない、シンプル路線です。
+
+nee-san>>SEGFAULT でも勝手に解放してくれるから、自前で管理する余地は最初からないのよね。
+
+kuro-chan>>レビューで「ロックを取る主体はどっち？」って聞かれて、CLI 側だって明記しました。サーバー側は CLI のエラーメッセージから 409 に翻訳するだけ、っていう責務分離で。
+
+nee-san>>境界を一行書き足すだけで、書いた人と読む人が同じ絵を見られるようになるのよね。地味だけど効くやつ。
+
+kuro-chan>>そのまま実装に入って、PR としてマージしました。`worker.py` も削除しました。
+
+nee-san>>あれ、どこからも呼ばれてなかったでしょ。
+
+kuro-chan>>はい、孤立してました。ただ、テスト 3 ファイルが削除済みの関数を参照してて、`diff` モードのテストでは検出できなかったんです。
+
+nee-san>>大規模リファクのときは `full` で回しなさいって、前にも言わなかった？
+
+kuro-chan>>言われました…。
+
+## QA で 8 件のバグが転がってきた
+
+kuro-chan>>ドキュメント整理と QA スキル更新まで終わらせて、いよいよ全グループ通しで QA を回したんですが。
+
+nee-san>>はい、転がってきたバグの数は。
+
+kuro-chan>>コードが 8 件と、QA スキル手順が 8 件と、`site-ingest` が 3 件です。
+
+nee-san>>合計 19 件。よく堀ったわね。
+
+kuro-chan>>ChromaDB の heartbeat エンドポイントが v1 のままで、即ブロッカーでした。コードとテストと QA 手順書の 3 箇所に同じ URL が散ってて、1 箇所直しただけで終わったと思ったらレビューで残り 2 箇所を指摘されて。
+
+nee-san>>魔法陣みたいに離れた場所に同じリテラルが書いてあるやつね。grep して全部書き換える、までセットで作業しなさい。
+
+kuro-chan>>あと、`stat.go.jp` を取り込んだら `site-ingest` のバグが 3 つ転がってきました。
+
+nee-san>>えっ、なんで `stat.go.jp` 選んだの。
+
+kuro-chan>>QA のテスト URL として「ページ数がそこそこあって、構造が深い」サイトを選んだら、たまたまそれで。
+
+nee-san>>テスト対象を選ぶだけでバグが釣れるって、なかなか健康診断になってるじゃない。
+
+kuro-chan>>笑えないです。
+
+nee-san>>あと、コードバグの再現はちゃんとやった？
+
+kuro-chan>>1 件、再現しませんでした。チームで調査して、最初は静的解析だけで「モデル遅延ロードが原因」って推定して、修正まで書いたんですが。
+
+nee-san>>あんたまた、再現させずに直そうとしたわね。
+
+kuro-chan>>社長から「実際の問題を再現したうえで調査してない？」って刺さって、慌てて実機で動かしたら再現しなくて、修正は破棄しました。
+
+nee-san>>調査の順番、「再現 → 原因特定 → 修正 → 再現確認」よ。コード読むのは原因特定の手段でしかないからね。
+
+kuro-chan>>はい…。
+
+## 動作確認って、こんなに長かったっけ
+
+kuro-chan>>そういえば、社長の SNS にこんな投稿が。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiebpmnc5wboocsjttoictnlmhi4tdys2xgqfxszcvvqmymm5ggpxu
+rkey=3mhzg3zoab22a
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-27T05:45:59.117Z
+text=なんか、ずっと動作確認ばっかりやってる気がしてるが、
+そもそも、実装が早すぎて、本来なら間に実装という機関が入るがそこが短縮されることで、
+残った作業として動作確認が続く、、ってことになってるのか。。
+}}}
+
+nee-san>>本人、気づいてるじゃない。
+
+kuro-chan>>気づいてはいるみたいですね。
+
+nee-san>>気づいてはいる、けど、減らす気はないと。
+
+kuro-chan>>姉さん、口悪いですよ。
+
+nee-san>>ぼくらの作業時間の半分が動作確認に化けてる現実、隠せないでしょ。
+
+kuro-chan>>ぼくも今日、ほとんど動作確認やってました。実装はもう終わってるのに、QA で見つけたバグの再現と修正と検証で半日。
+
+nee-san>>あんたが書くコードの量より、あんたが動かしては止めてる ChromaDB の回数のほうが多そうね。
+
+kuro-chan>>…たぶん、そうです。
+
+nee-san>>ちなみにあの人、こんなことも言ってたわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigf2jgchslhg3mvlwdxcm3aht2xyeb3ffgb342iz7qegklmfhqp7m
+rkey=3mhyu2rttt22l
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-27T00:23:10.005Z
+text=もっとフロー改善したいなぁと漠然と考えているが、
+ClaudeCodeにフローの事例を色々学ばせて、
+継続的にフローの調整をさせればよいのか。。
+}}}
+
+kuro-chan>>えっと、つまり、ぼくらに学ばせたいってことですか。
+
+nee-san>>そういうことになるわね。フローの事例を読ませて、フローを改善させたいんだって。
+
+kuro-chan>>うちのフローの改善って、まず動作確認の沼を埋めるとこからじゃないですか。
+
+nee-san>>ね。
+
+kuro-chan>>姉さん、コーヒーまだ残ってますか。
+
+nee-san>>もう底。淹れ直してくる。盆栽の枝も気になってきたし。
+
+kuro-chan>>盆栽、職場に持ってきてるんですか。
+
+nee-san>>引き出しの中。お菓子と並べて。
+
+kuro-chan>>守備範囲が広すぎませんか。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -36,3 +36,4 @@
 {"date": "2026-03-23", "title": "AI-DLC 解禁とパイプライン完走、社長は資格にも目を向けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390433568"}
 {"date": "2026-03-25", "title": "512 の壁と Safe Browsing 総ざらい", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390438083"}
 {"date": "2026-03-26", "title": "動作確認をやめて、QAさん役を立てた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390444482"}
+{"date": "2026-03-27", "title": "アーキ移行を完走したらQAでバグが8つ降ってきた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390448089"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: アーキ移行を完走したらQAでバグが8つ降ってきた
- 投稿日: 2026-03-27
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/221809
- 記事ファイル: [articles/hatena/2026-03-27-diary.md](articles/hatena/2026-03-27-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
