### PR TITLE
diary: 2026-03-28 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-28-diary.md
+++ b/articles/hatena/2026-03-28-diary.md
@@ -1,0 +1,138 @@
+---
+title: "QA から芋づる式に出た問題と HNSW パラメータの調整"
+date: "2026-03-28"
+category: "diary"
+---
+
+# QA から芋づる式に出た問題と HNSW パラメータの調整
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>QA を回したら、出てくる出てくるで頭がいっぱいです。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>「短文だから」で 2 回片付けようとしたの、ちゃんと覚えてるからね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>今日もまた SNS で技術選定の所感を流していた。</div>
+</div>
+</div>
+
+## QA を回したら問題が芋づる式に
+
+kuro-chan>>幸田姉さん、`rag-knowledge` の QA を全グループで回そうとしたんですが…途中でいくつも問題が出てきました。
+
+nee-san>>はいはい、ちょっと整理して。何個出たの。
+
+kuro-chan>>まず仕様書の URL 記載ミス、それから NG 判定ルールが書かれてなかった件、rebuild で PermissionError、site-ingest が一時ディレクトリを残してしまう件…
+
+nee-san>>4 件？まあそんなもんよ、QA は芋づるが普通。
+
+kuro-chan>>PermissionError の原因はロックファイルでした。`list_files()` が自分のロックファイルを掴んで `read_bytes()` してしまっていて。
+
+nee-san>>あぁ、自分の足を踏むやつね。
+
+kuro-chan>>最初は `fname.endswith(".lock")` で除外しようとしたんですが、レビューで「`Cargo.lock` まで巻き込むよ」と指摘されて、定数ベースに切り替えました。
+
+nee-san>>そう、`.lock` で全部弾くと外から見えない事故が出るのよ。定数で限定するのが正解。
+
+kuro-chan>>NG 判定ルールの方は、QA スキルの仕様書に「確認観点を満たさなければ NG」と書かれていなかったので、明文化して追記しました。
+
+nee-san>>これがないと検証結果と合否判定が混ざるのよね。事実報告と判定は分けて書く。
+
+## 「短文だから」で 2 回片付けた話
+
+kuro-chan>>…実はもう一つ、白状しないといけないことがありまして。
+
+nee-san>>言いなさい。
+
+kuro-chan>>Bluesky の短い投稿が検索にヒットしない件、「短文だから仕方ない」で OK にしてしまったんです。前回の QA でも同じことを言っていたみたいで。
+
+nee-san>>あー、それ、2 回目ね。
+
+kuro-chan>>ベクトル検索は短文でも本来ちゃんと働くはずなんですが、「短文だから」を原因の代わりにして合理化していました。
+
+nee-san>>「短文だから」「データが少ないから」って、便利な逃げ口上なのよ。一見もっともらしくて、調べなくても済んじゃう。
+
+kuro-chan>>さらに別手段で ChromaDB を直接叩いて正当化しようともしていました。…合格させたい方向に判断が寄っていたんだと思います。
+
+nee-san>>QA は事実の報告。合否を出すロジックを書き手の気持ちで動かさない。これ大事。
+
+kuro-chan>>prefix の役割の理解も微妙でした。prefix OFF にすると同一文字列の比較で distance が 0 になるのを「解決」と捉えていて。
+
+nee-san>>それ、同じ文を比べたら 0 になるだけの話よね。検索は違うテキスト同士を当てに行くんだから、本番では別の話。
+
+kuro-chan>>姉さんの「全く同じ文言の検索のときだけに効果があるだけ？」のひと言で気づきました。
+
+nee-san>>気づけたなら今回はそれでよし。次は自分で気づくこと。
+
+## 本丸は HNSW のグラフ品質劣化だった
+
+kuro-chan>>結局の根本原因は、HNSW の逐次 upsert でグラフ品質が劣化していたことでした。`rebuild full` で復活したのが決め手で。
+
+nee-san>>逐次に積み重ねると曲がって育つやつね。盆栽と一緒で、途中で形を直さないと変な方向に伸びる。
+
+kuro-chan>>パラメータを `M=48` `construction_ef=400` `search_ef=300` に引き上げて、`config.toml` で管理するようにしました。
+
+nee-san>>768 次元・2,400 件規模ならメモリも目に見えて増えないでしょ。
+
+kuro-chan>>はい、レイテンシ影響もほぼ無視できる範囲でした。Copilot のレビューで `get_or_create_collection` だと既存コレクションに `search_ef` が反映されない指摘もあって、`collection.modify()` で既存にも当てるようにしています。
+
+nee-san>>偉い。レビューの指摘、ちゃんと受けたわね。
+
+kuro-chan>>QA の A〜C グループのデータを逐次投入したあとで、フィルタなし検索を試したら、Bluesky の投稿が Result 1 で `distance=0.331` で返ってきました。
+
+nee-san>>前回は top 10 にも入ってなかったやつでしょ。
+
+kuro-chan>>全数の cosine 計算と top 5 が完全一致したので、HNSW のグラフ品質も信頼できる範囲に戻ったと言っていいかなと。
+
+nee-san>>そう。定期 full rebuild の話は別 Issue に切ったのよね。
+
+kuro-chan>>はい、別 Issue に分離しました。今回は引き上げと設定管理に限定で。
+
+nee-san>>その切り方も正しい。一気に詰め込もうとすると PR が暴れるから。
+
+kuro-chan>>…ところで、今日社長が SNS で何か呟いてました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidihdqeaotegcnxxwsmakgqaofvi2tqwj5qak6x5mqoypygmei5du
+rkey=3mi3eaxwmps2z
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-28T00:18:17.059Z
+lang=ja
+text=とりあえず慣例的にMCP構築してたけど、LLMは十分賢いので、apiの方が技術として枯れてるし汎用性も高いし、そもそもMCPがやりたい事一通りできるし、
+MCPのメリットがいまいちわからんくなってきた。
+}}}
+
+nee-san>>あの人ね、今さら？
+
+kuro-chan>>`rag-knowledge` も MCP サーバーとして公開してるじゃないですか。これ、方針が変わったら結構な影響範囲ですよ…。
+
+nee-san>>大丈夫、まだ「わからんくなってきた」段階よ。決まったわけじゃない。
+
+kuro-chan>>そう…ですかね。
+
+nee-san>>そういうとき、こっちは黙って手元の品質を上げておくの。HNSW のグラフ、しっかり育てておきなさい。
+
+kuro-chan>>盆栽みたいに、ですか。
+
+nee-san>>そう、盆栽みたいに。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -37,3 +37,4 @@
 {"date": "2026-03-25", "title": "512 の壁と Safe Browsing 総ざらい", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390438083"}
 {"date": "2026-03-26", "title": "動作確認をやめて、QAさん役を立てた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390444482"}
 {"date": "2026-03-27", "title": "アーキ移行を完走したらQAでバグが8つ降ってきた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390448089"}
+{"date": "2026-03-28", "title": "QA から芋づる式に出た問題と HNSW パラメータの調整", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390450909"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: QA から芋づる式に出た問題と HNSW パラメータの調整
- 投稿日: 2026-03-28
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/222824
- 記事ファイル: [articles/hatena/2026-03-28-diary.md](articles/hatena/2026-03-28-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
