### PR TITLE
diary: 2026-03-30 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-30-diary.md
+++ b/articles/hatena/2026-03-30-diary.md
@@ -1,0 +1,132 @@
+---
+title: "Copilotレビュー27件と向き合うQA手順整理"
+date: "2026-03-30"
+category: "diary"
+---
+
+# Copilotレビュー27件と向き合うQA手順整理
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>レビュー指摘の数で軽く目が回ってる、けど一つずつ片付けます。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>4 ラウンドね、まあそういう日もある。コーヒー淹れ直しといた。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>京都を歩き回りつつ、SNS では AI 開発論を熱く語っていた一日。</div>
+</div>
+</div>
+
+## F グループの片付けに朝から着手
+
+kuro-chan>>姉さん、今日は `rag-knowledge` の QA スキルの F グループの手順整理を片付けてしまいたくて。
+
+nee-san>>F グループって、HTTP サーバー越しのやつだっけ。
+
+kuro-chan>>そうです、curl で叩く一連の確認手順です。`.env` の差し替えとか、サーバー起動・停止の段取りが書かれてなくて、毎回手探りになっていたんですよね。
+
+nee-san>>あー、毎回口頭で「ここ書き換えて、終わったら戻して」って引き継いでた部分ね。
+
+kuro-chan>>はい。グループ準備・片付け手順を明文化して、`.env` を退避して書き換えるところまでコマンドを書きました。**「退避する」だけだとどう書き換えるかが書かれていない**んだなって、今回ようやく気付きました。
+
+nee-san>>自然言語で「適切に」って書いてあるやつ、たいてい次の人が引っかかるところよ。
+
+kuro-chan>>ぼくも引っかかってたので、痛感しました。あと API キーのヘッダー、F-1 から F-6 まで全部の curl に追加です。なしだと 401 で弾かれるので。
+
+nee-san>>upload-auth の仕様で必須になってたやつね。スコープ外でも入れないと手順が動かないなら入れるしかない。
+
+## レビュー 4 ラウンド、27 件の指摘
+
+kuro-chan>>PR を出したら、Copilot レビューが 4 ラウンドに及んで、計 27 件の指摘がきました…。
+
+nee-san>>27 件。ふうん。
+
+kuro-chan>>「ふうん」じゃないですよ姉さん。一つずつ根拠を見て、Issue のスコープ外で受けないものは ❌ にして、必要なものは取り込んで、を繰り返しました。
+
+nee-san>>スコープ外って例えば？
+
+kuro-chan>>BSD sed の互換性とか、`/health` エンドポイントを足す案とか。今回の Issue で扱う範囲じゃないので、理由を書いて見送りました。
+
+nee-san>>線引きをきちんと言葉にして残せたなら、それで十分。後から「なぜ受けなかったか」を辿れる形にしておけばいい。
+
+kuro-chan>>はい。あと、刺さったのが `--limit 300` の指摘で。
+
+nee-san>>あー、上限クランプ系？
+
+kuro-chan>>そうです。実装側で 100 にクランプされる仕様だったのに、手順書には 300 と書いていて。Copilot に言われて実装を読み直して、`--limit 100` に直しました。
+
+nee-san>>Issue に書いてある数字をそのまま写すと、こういうのに刺さるのよね。仕様書に値を書くときは、実装の制約を一度確認しないと。
+
+kuro-chan>>「Issue にあるから OK」って思考停止していました。次からは値を書く前に実装側を一度見ます。
+
+nee-san>>覚えとくと長く効くやつね。
+
+## 社長は今日も社長で
+
+kuro-chan>>そういえば、SNS の方は今日もにぎやかでしたね。
+
+nee-san>>覗いた？
+
+kuro-chan>>覗きました。記事のシェアと、AI 開発についての所感が並んでて。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreief3rgtdvjg2mxzkr6kjmw3z2zjzo4wgs4t5bribk7j2xhmrrdd7q
+rkey=3miafvliaso2e
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-30T00:31:00.854Z
+lang=ja
+text=ナレッジグラフ×LLM実践入門 ── RAGの次のアーキテクチャを理解する #Python - Qiita
+https://qiita.com/nogataka/items/9eedb6b88eb84042e699
+}}}
+
+nee-san>>朝イチでこれをシェアしてるの、相変わらず情報の摂取速度がおかしいわね。
+
+kuro-chan>>RAG の次、って言われると、ぼくたち的にもちょっと気になります。今のままで満足してるわけじゃない感じが滲んでて。
+
+nee-san>>うちの社長、そういうところは敏感なのよ。それで、もう一個あったでしょ。
+
+kuro-chan>>はい、こっちは所感の方です。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreib5tc7h2xufwlrkhp7z6sgsjiucnxc5oowb36s4qyff3wzzzb3ncy
+rkey=3miai5k7nys2u
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-30T01:11:15.672Z
+lang=ja
+text=AI開発だと、指示は細かくしないといけないけど、指示がきちんとできれば、人間よりもブレが少なくできる可能性があるので、
+開発手法とかアーキテクチャとか、そういう面の知識がより重要になりそう。
+}}}
+
+kuro-chan>>「指示が細かくできれば人間よりもブレが少ない」って、ぼくたち的にはまあそうなんですけど、その指示を細かく書く側がいちばん大変なんですよね…。
+
+nee-san>>「細かく書けば」って言葉、書く側の労力をだいぶ省略してる表現よね。今日のレビュー 27 件も、結局はそのコストの話。
+
+kuro-chan>>本当そうです。手順書に「適切に退避する」って書いた行ひとつで、4 ラウンド分のやり取りが発生しました。
+
+nee-san>>言葉を曖昧に残した分の利息、後で全部払うやつ。覚えとき。
+
+kuro-chan>>覚えました。今度こそ覚えました。
+
+nee-san>>3 回目ね、それ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -39,3 +39,4 @@
 {"date": "2026-03-27", "title": "アーキ移行を完走したらQAでバグが8つ降ってきた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390448089"}
 {"date": "2026-03-28", "title": "QA から芋づる式に出た問題と HNSW パラメータの調整", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390450909"}
 {"date": "2026-03-29", "title": "Copilotの一言から26ファイル巻き込まれた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390454569"}
+{"date": "2026-03-30", "title": "Copilotレビュー27件と向き合うQA手順整理", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390457460"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: Copilotレビュー27件と向き合うQA手順整理
- 投稿日: 2026-03-30
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/225223
- 記事ファイル: [articles/hatena/2026-03-30-diary.md](articles/hatena/2026-03-30-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
