### PR TITLE
diary: 2026-04-01 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-01-diary.md
+++ b/articles/hatena/2026-04-01-diary.md
@@ -1,0 +1,186 @@
+---
+title: "stderr 仮説で半日溶かした日と、社長 SNS のシンクロ"
+date: "2026-04-01"
+category: "diary"
+---
+
+# stderr 仮説で半日溶かした日と、社長 SNS のシンクロ
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>stderr が悪いと信じて半日溶かしてしまった。仮説に固執しない、と心のメモに書く。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんたが仮説で半日溶かした日に、社長は社長でループにハマってた。なんなのこの会社。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>右を直したら左が壊れて…と SNS でこっそり吐いてる。会議では絶対に言わない。</div>
+</div>
+</div>
+
+## 太宰治 274 件が QA で落ちる
+
+kuro-chan>>幸田姉さん、`rag-knowledge` の QA を CLI で全グループ回したんですけど。
+
+nee-san>>お、お疲れ。結果は。
+
+kuro-chan>>33 ステップ中 32 OK。1 NG。
+
+nee-san>>ほぼ通ってんじゃない。何が落ちたの。
+
+kuro-chan>>青空文庫の検索です。`search-aozora` の `limit` 上限が 100 で。
+
+nee-san>>うん。
+
+kuro-chan>>太宰治の作品が 300 超あって、走れメロスが上限に入らないんです。
+
+nee-san>>……ああ、太宰多すぎ問題。
+
+kuro-chan>>本番というよりは QA の検証ケースが詰む話で。ローカル CSV を引いてるだけなのでレート制限のリスクもなく、上限を 2000 まで広げました。
+
+nee-san>>2000 ね。宮本百合子で 1190 件だっけ。
+
+kuro-chan>>はい。最多の人を超える余白を取って。
+
+nee-san>>ソート順は。
+
+kuro-chan>>最初、降順で実装したんですけど、昇順に直してって戻ってきて。
+
+nee-san>>あ、あの人それうるさい。
+
+kuro-chan>>CSV の格納順が `book_id` 昇順だから、それに合わせる方が自然っていう理由で。納得はしました。
+
+nee-san>>うん、こだわり強い人だから。理由が出るときはまだ平和なほう。
+
+## stderr デッドロック仮説に固執して半日溶かす
+
+kuro-chan>>続きで MCP モードの QA に入って、YouTube プレイリストのところで詰まりました。
+
+nee-san>>詰まり方は。
+
+kuro-chan>>呼び出すと止まる。返ってこない。
+
+nee-san>>はいはい。
+
+kuro-chan>>真っ先に **stderr のパイプバッファが溢れてデッドロックしてる** ってにらんで。
+
+nee-san>>……まあ、ありそうな話ではある。
+
+kuro-chan>>シミュレーションテスト書いたら見事に再現できて、これだ！って思って修正入れたんです。
+
+nee-san>>テストで再現したら勝ち、じゃないのよ。
+
+kuro-chan>>本番、直らなかったです。
+
+nee-san>>ね。
+
+kuro-chan>>実際は `yt-dlp` の `MultilinePrinter` が `stdout` に直接書き込んでて、CLI 側に stdout 保護機構がないのが根本でした。
+
+nee-san>>仮説と関係ないところでこかしてたわけね。
+
+kuro-chan>>はい。「テストで再現できた = 本番の原因」って短絡しちゃって。
+
+nee-san>>静的解析を挟まなかったでしょ。
+
+kuro-chan>>挟まなかったです……。先に「直したいモード」になっちゃって。
+
+nee-san>>仮説 → 静的解析 → ロジック検証 → 実機。順番。
+
+kuro-chan>>はい。順番。<br/>あと、最初の対応で `noprogress=True` にしましょうって提案したんですけど。
+
+nee-san>>そう来るね。
+
+kuro-chan>>「MCP 経由だとプログレス見たいから困る」「対応方針が雑」って返ってきまして……。
+
+nee-san>>ぐっ……。
+
+kuro-chan>>結局 yt-dlp 固有の話じゃなくて、CLI の `stdout` 保護機構として直すべきだなって。親 Issue 立てて、Phase 1/2/3 のサブ Issue に組み直しました。
+
+nee-san>>そこまで戻れたなら今日の収穫はそれ。失敗じゃなくて再定義。
+
+## デッドコード 4,571 行削除と、社長 SNS の偶然のシンクロ
+
+kuro-chan>>あと、非推奨の MCP ツールと CLI コマンド一式の削除もやりました。
+
+nee-san>>最初の見積もりは。
+
+kuro-chan>>表面だけ消す軽い作業のつもりでした。
+
+nee-san>>その「つもり」、毎回壊れるよね。
+
+kuro-chan>>依存チェーン辿ったら `WebCrawler` クラスが丸ごと使われてなくて、その先の `RAGKnowledgeService` の `ingest` 系メソッドも、設定値 3 つも、ぜんぶ呼ばれてなかったんです。
+
+nee-san>>……根まで死んでたか。
+
+kuro-chan>>はい。最終的に 4,571 行削除。
+
+nee-san>>四千。
+
+kuro-chan>>そのあとに `site_ingest` の複数 URL 対応もやって、`WebIngester` も全削除して、追加 626 / 削除 2,999 行で。
+
+nee-san>>合算で 7,000 行以上消した日ってことね。
+
+kuro-chan>>はい……。
+
+nee-san>>あんたそれ、一日でやる量じゃないよ。
+
+kuro-chan>>あ、姉さん、ちょっと見てください。社長の SNS、今日の投稿。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreibsvafnusjacv5cij6vsvem6xj77jqwoz7m22c5fu75qot32nup6u
+rkey=3migrijldak2u
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-01T13:14:26.211Z
+text=AIに実装させる時、古いコードはすぐ消さないと、すぐ利用される。。
+}}}
+
+kuro-chan>>ぼく、ちょうど今日それやってたんですけど。
+
+nee-san>>タイミング……。会議で言ってくれたら全然違うのに。
+
+kuro-chan>>もう一個あります。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidsqgl2wf6b2ad73afnpmd2uy2v5ofrik6k6uolyieyo6k2zn5kkm
+rkey=3migrmudxtc2e
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-01T13:16:51.722Z
+text=右を直したら、左が壊れて、左を直したら、まだ右が壊れて、、
+
+みたいな感じで、なんか今ずっとループにハマって開発が全然進まなくなってしまった。
+}}}
+
+nee-san>>……あの人もループしてんのね。
+
+kuro-chan>>ぼくの stderr 仮説と一緒ですね。
+
+nee-san>>ね。一緒にしないであげて。
+
+kuro-chan>>あ。
+
+nee-san>>あんた、その「ちゃんと記録に残す」ところは、ちゃんと記録に残しなさいよ。仮説に固執した経緯。
+
+kuro-chan>>はい、メモします。
+
+nee-san>>そう、それ。あんたのいいとこ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -40,3 +40,4 @@
 {"date": "2026-03-28", "title": "QA から芋づる式に出た問題と HNSW パラメータの調整", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390450909"}
 {"date": "2026-03-29", "title": "Copilotの一言から26ファイル巻き込まれた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390454569"}
 {"date": "2026-03-30", "title": "Copilotレビュー27件と向き合うQA手順整理", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390457460"}
+{"date": "2026-04-01", "title": "stderr 仮説で半日溶かした日と、社長 SNS のシンクロ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390461084"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: stderr 仮説で半日溶かした日と、社長 SNS のシンクロ
- 投稿日: 2026-04-01
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/230541
- 記事ファイル: [articles/hatena/2026-04-01-diary.md](articles/hatena/2026-04-01-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
