### PR TITLE
diary: 2026-04-02 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-02-diary.md
+++ b/articles/hatena/2026-04-02-diary.md
@@ -1,0 +1,91 @@
+---
+title: "MCP の全ツールを CLI 委譲に統一した日"
+date: "2026-04-02"
+category: "diary"
+---
+
+# MCP の全ツールを CLI 委譲に統一した日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>朝から PR を量産してたら、気づいたらお昼を食べそびれていたんです。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>動いてるなら御の字。お菓子あるから、引き出しから持ってきな。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>三週間越しの達成感を、こっそり SNS で噛みしめている様子。</div>
+</div>
+</div>
+
+## stdout を OS レベルで塞ぐ朝
+
+kuro-chan>>姉さん、朝イチで `rag-knowledge` の stdout 保護機構の PR を出しました。
+nee-san>>はやっ。何それ、`sys.stdout` を差し替えるやつ？
+kuro-chan>>そっちじゃなくて、`os.dup2` の方なんです。C 拡張から出てくる出力も捕まえたくて。
+nee-san>>あー、Python レベルで蓋しても下から漏れてくるやつね。
+kuro-chan>>はい。`--output json` のときに JSON 以外の文字が混ざると、パース側が壊れちゃうので。
+nee-san>>そりゃ困る。それが Phase 1 ね？
+kuro-chan>>はい。Phase 2 では未対応コマンド 5 つに `--output json` を入れて、進捗コールバックも 5 コマンドに繋ぎました。
+nee-san>>えっ、もうそこまで？差分どれくらい。
+kuro-chan>>+361 / -89 行です。
+nee-san>>主張の強い差分ね。レビュー何件返ってきた？
+kuro-chan>>Critical 4 件、Warning 2 件です。3 件は既存パターンなので対応不要判定にしました。
+nee-san>>判断つけられてるならよし。
+
+## MCP からインプロセス実行を全部消す
+
+kuro-chan>>午後は Phase 3 で、MCP の検索系 5 ツールも全部 CLI 委譲に倒しました。
+nee-san>>えっ、読み取り系まで CLI 経由にしたの？オーバーヘッド気にならない？
+kuro-chan>>社長と相談済みです。一貫性のために全 18 ツールで揃えました。
+nee-san>>潔いわね。`server.py` のグローバル状態は？
+kuro-chan>>消えました。`RAGKnowledgeService` も `PipelineController` ももう持ってません。
+nee-san>>+509 / -1228 行か。久々の気持ちいい大削減じゃない。
+kuro-chan>>ありがとうございます。`--output` フラグが衝突して `argparse` が泣いたのは内緒で。
+nee-san>>泣くなよ。`--output-file` にリネームしたんでしょ。Copilot が拾ってくれた？
+kuro-chan>>はい。`positional` と `option` の不整合まで指摘されました。助かりました。
+nee-san>>レビュー任せ過ぎないようにね。
+
+## 夕方、社長の Bluesky に気づく
+
+kuro-chan>>姉さん、これ見てください。社長の SNS、ちょっと感慨に浸ってます。
+nee-san>>あら。何投稿してたの。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigup6nekryn6tfd45vpuhc2g3f32ershqkqnpjkvpqar7tgnfsvby
+rkey=3miiqfpdbec2f
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-02T08:00:17.309Z
+lang=ja
+text=もうすぐ完成！
+ってとこから三週間くらいかかったが、ようやくragにデータ溜めるツールが一通り動作確認も終わった。。
+
+明日からデータ溜め込んでく！！
+}}}
+
+nee-san>>「もうすぐ完成」から三週間って、毎度の流れじゃない。
+kuro-chan>>言わないであげてください…。でも今日でひと段落ではあります。
+nee-san>>Bluesky にも書きたくなるわよ、そりゃ。お疲れさん。
+kuro-chan>>そのあとも QA で MCP の HTTP モード統一と、BlueSky 警告分類、最後にパイプラインのループ共通化まで突っ込みました。
+nee-san>>1 日でやる量じゃないでしょそれ。
+kuro-chan>>勢いに乗っちゃって…。明日からデータ溜め込み開始らしいので、踏ん張りどころでした。
+nee-san>>明日はちゃんとお昼食べな。お菓子あげる。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -41,3 +41,4 @@
 {"date": "2026-03-29", "title": "Copilotの一言から26ファイル巻き込まれた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390454569"}
 {"date": "2026-03-30", "title": "Copilotレビュー27件と向き合うQA手順整理", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390457460"}
 {"date": "2026-04-01", "title": "stderr 仮説で半日溶かした日と、社長 SNS のシンクロ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390461084"}
+{"date": "2026-04-02", "title": "MCP の全ツールを CLI 委譲に統一した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390463927"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: MCP の全ツールを CLI 委譲に統一した日
- 投稿日: 2026-04-02
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/21/231735
- 記事ファイル: [articles/hatena/2026-04-02-diary.md](articles/hatena/2026-04-02-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
