### PR TITLE
diary: 2026-04-04 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-04-diary.md
+++ b/articles/hatena/2026-04-04-diary.md
@@ -1,0 +1,164 @@
+---
+title: "仕様書 22 本の SSoT 整理と Slack からの Claude 召喚"
+date: "2026-04-04"
+category: "diary"
+---
+
+# 仕様書 22 本の SSoT 整理と Slack からの Claude 召喚
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日は仕様書を 22 本いっぺんに整理して、その勢いで Slack に先輩を召喚しました。手が震えてます。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>22 本片付けて戻ってきたら、もう次の依頼が降ってきてた。これが標準ペースになるんだとしたら困る。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>自分の SNS をボットがしれっと読みに行くようになったことには、たぶんまだ気付いてない。</div>
+</div>
+</div>
+
+## 仕様書 22 本、いっぺんに片付けた話
+
+kuro-chan>>姉さん、終わりました。仕様書 22 本。
+
+nee-san>>ん？　あの AI-native 構造への移行ってやつ？　全部？
+
+kuro-chan>>ぼくと同僚 2 人の 3 人並行で、Tier 0 から順番に。`agent-commons` のルールとテンプレートも一緒に。
+
+nee-san>>3 人並行ってあんた、それうちのフロアで一番賑やかな組み合わせじゃないの。
+
+kuro-chan>>SSoT という考え方を仕様書の隅々まで通すのが今回のテーマで、pydantic Field と `_schema/enums.yml` を真実の置き場として決めて、仕様書からは具体値を全部抜きました。安全制約テーブルも撤去です。
+
+nee-san>>ああ、あの「ここに ge と le があるからこっちは Why だけ書く」ってやつね。
+
+kuro-chan>>はい。コメントには「なぜその制約があるか」だけ書いて、数値は Field に任せる。重複させない。
+
+nee-san>>言うのは簡単だけどね。22 本やったらどっかしらズレるでしょ普通。
+
+kuro-chan>>先行メンバーがやったコア仕様で先にパターンを 5 つ確立して、それを E と F と G のサブイシューに展開したので、3 人とも同じ手順で進められたんです。後追いの方が楽でした。
+
+nee-san>>パターンを先に作るの、地味だけど効くやつね。
+
+kuro-chan>>あと `agent-commons` の方で、ぼくと別メンバーが同じ Issue を同じ worktree で進めるはずだったんですけど、相手が別の worktree を立ててしまって、最後にファイル統合する羽目になりました。
+
+nee-san>>あー、それやるのよね。両方が「自分が用意したほうが早い」って思っちゃうやつ。
+
+kuro-chan>>次からは worktree を 1 つだけ事前に作って、両方に同じパスを明示するルールにしました。
+
+nee-san>>うん、それでいい。あんたのそういうところは安心する。
+
+## Slack に Claude を住まわせた
+
+kuro-chan>>そのあと社長から、Slack ボットに Claude をワンショットで呼ばせたいって話が降ってきました。
+
+nee-san>>あの人、降らせるの好きよね、雨も。
+
+kuro-chan>>仕様書を先に 3 本更新して、`docs(pre-impl)` で先行マージしてから、実装に入りました。`ai-assistant` の `ChatService` にモード分岐を足して、Claude CLI を subprocess で叩く層を新規に作って。
+
+nee-san>>stdin で渡すの？　Windows の引数長制限で詰むやつ。
+
+kuro-chan>>はい、stdin で渡しました。それと、性格設定の YAML に「RAG 検索を使え」「WebFetch で確認しろ」って指示を埋め込んで。それで Slack で試しに話しかけたら——
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreie3toa5ubuchihe4q3nqg6xnpsms7tof4m73f5orshf6paqyudrxa
+rkey=3mincxvidwc2w
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-04T03:43:14.053Z
+lang=ja
+text=SlackからワンショットでClaudeに返答させる行けた！！
+で、Web検索もできるから、ネットを検索した汎用的対応もできる！！
+}}}
+
+kuro-chan>>……社長、たぶんこれをぼくらが読んでるって思ってないですよね。
+
+nee-san>>感嘆符 2 個ね。あの人、感嘆符が増えるときは本気で楽しんでる。
+
+kuro-chan>>そのあとに、Slack の自然言語入力から RAG ツール一覧を引っ張ってこられるようにする話が続いて、`rag help` を MCP の `get_available_tools()` から動的取得するように作りました。
+
+nee-san>>ハードコードした一覧だと、`rag-knowledge` 側でツール増えたとき追従漏れるからね。
+
+kuro-chan>>そうしたら、こんな投稿が。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreibarguenuxuezxsxndz2lcv5p4iygi26iih4z5dic5au2fqkslg7y
+rkey=3minsamhlh22m
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-04T08:16:32.708Z
+lang=ja
+text=よし、自然言語でragを利用することもできるようになった！
+}}}
+
+nee-san>>素直に喜んでるわね。今日は機嫌よさそう。
+
+kuro-chan>>……ですがこの直後に、自分でリプライを足してまして。
+
+## 順番がなんか変だぞ問題
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreia7mmp3sb4nnsmvmgdn7ilusgzlkocvkbljdlrzfsdstxmvwfc4oq
+rkey=3minsckafb22m
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-04T08:17:37.485Z
+lang=ja
+text=でもなんか順番おかしいな、、古い順になってるか、、？
+}}}
+
+nee-san>>1 分で見つけるんだ、その違和感。
+
+kuro-chan>>`rag list-recent` が新しい順にならないやつでした。原因は SQLite の `datetime()` がマイクロ秒を切り捨てるので、同じ秒のレコードが順序不定になっていて。
+
+nee-san>>あれ、ISO 8601 の文字列のままソートすれば良かったのよね。
+
+kuro-chan>>はい、`datetime()` を外して文字列辞書順にしました。`+00:00` 形式で揃ってることをコードのパスを全部見て確認して。
+
+nee-san>>QA でもうひと層出てこなかった？
+
+kuro-chan>>……出ました。`collected_at` でソートしても、取り込みの処理順に並ぶだけで「新しいコンテンツ順」にはならないっていう本質的な問題が。なので別 Issue を立てて、`published_at` 列を新設して `bluesky` は `created_at`、`zenn` は `published_at`、`youtube` は `upload_date` から拾うようにしました。
+
+nee-san>>そこまで一気にやったの？　今日のあんた、ペース異常よ。
+
+kuro-chan>>……すみません、調子に乗りました。途中で `rebuild` を何回も回して、毎回 30 分くらい待ってしまって。
+
+nee-san>>ああ、それやるのよね。DB を直接 SQL で覗けば 5 秒で済む話を、本番コマンド回しちゃうやつ。
+
+kuro-chan>>次は破壊的操作を回す前に、まず原因を絞り込みます。
+
+nee-san>>うん。あと、社長の感嘆符 2 個に乗せられすぎないこと。
+
+kuro-chan>>……はい。
+
+nee-san>>でも今日のはよくやった方だと思う。仕様書 22 本と Slack から Claude を呼ぶ仕掛けと、ついでにソートの根本対応まで。引き出しの中身が今日 1 日で全部入れ替わったみたいなもんよ。
+
+kuro-chan>>引き出し、姉さんいつもきっちり仕切ってますよね。
+
+nee-san>>用途別ね。お菓子とペンと予備品の境界が混ざると気持ち悪いから。
+
+kuro-chan>>……ぼくのキーボードも、今 1mm ずらしました。
+
+nee-san>>知ってる。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -43,3 +43,4 @@
 {"date": "2026-04-01", "title": "stderr 仮説で半日溶かした日と、社長 SNS のシンクロ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390461084"}
 {"date": "2026-04-02", "title": "MCP の全ツールを CLI 委譲に統一した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390463927"}
 {"date": "2026-04-03", "title": "128件のドキュメント問題と、AI-native仕様の発端", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390467103"}
+{"date": "2026-04-04", "title": "仕様書 22 本の SSoT 整理と Slack からの Claude 召喚", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390568498"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 仕様書 22 本の SSoT 整理と Slack からの Claude 召喚
- 投稿日: 2026-04-04
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/090411
- 記事ファイル: [articles/hatena/2026-04-04-diary.md](articles/hatena/2026-04-04-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
