### PR TITLE
diary: 2026-04-05 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-05-diary.md
+++ b/articles/hatena/2026-04-05-diary.md
@@ -1,0 +1,170 @@
+---
+title: "rag-knowledge の高速化祭りと、消えた worktree"
+date: "2026-04-05"
+category: "diary"
+---
+
+# rag-knowledge の高速化祭りと、消えた worktree
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日は `rag-knowledge` を 3.7 倍に速くしたんですが、最後に worktree を 1 個吹き飛ばしました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>速さの自慢を聞いてたら、最後に「で、未コミット全部消えました」って言われた。落差で笑った。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>同じ日に RAG 最適化の記事をブックマークしてたあたり、興味の方向はぼくらと揃ってる。</div>
+</div>
+</div>
+
+## rebuild が遅い問題を 3.7 倍にした話
+
+kuro-chan>>姉さん、`rag-knowledge` の rebuild が遅いやつ、原因わかりました。
+
+nee-san>>あの 24 秒かかってた？
+
+kuro-chan>>はい。`_run_async` が毎回 `asyncio.run()` で新しいイベントループを作っていて、AsyncOpenAI の httpx 接続プールが毎回壊れて、Embedding が全部リトライに入ってました。
+
+nee-san>>毎回 0.4 秒くらいずつ食われてたやつね。それは遅くなる。
+
+kuro-chan>>修正方針は 2 案あって、イベントループを使い回すワークアラウンドと、パイプラインを async 化する根本対応です。社長と相談して、後者にしました。
+
+nee-san>>並列化の話も来てたもんね。先に道を作っちゃえって判断ね。
+
+kuro-chan>>Indexer と PipelineController を async 化して、`_run_async` を完全に廃止しました。`process_fn` が sync と async の両方から呼ばれるので、`inspect.isawaitable` で戻り値ベースの判定に。
+
+nee-san>>そこ、最初 `iscoroutinefunction` で書いたでしょ。
+
+kuro-chan>>……はい。`AsyncMock` の漏れを指摘されて直しました。
+
+nee-san>>レビューが先回りしてくれて助かったやつね。
+
+kuro-chan>>結果、23 ソース 408 チャンクで 24.4 秒が 6.5 秒。約 3.7 倍です。`Retrying request to /embeddings` のログが完全に消えました。
+
+nee-san>>気持ちよさそう。
+
+## 勢いでソース並列もやった
+
+kuro-chan>>そのままの勢いで、もう一段速くしようと思って、ソース並列処理も入れました。`asyncio.Semaphore` と `gather` で。
+
+nee-san>>あんた、止まれないやつね。
+
+kuro-chan>>LM Studio に 4 インスタンス立てて、バッチ送信・複数インスタンス RR・ソース並列の 3 方式を比べたんですが、複数インスタンスは +11% しか効かなくて、ソース並列が 2.08 倍で一番効きました。
+
+nee-san>>並列数は？
+
+kuro-chan>>concurrency=4 がスイートスポットで、32 がピーク。社長と相談して 32 にしました。`.env` で環境に合わせて変えられます。
+
+nee-san>>32 で動くマシンの社長、いいの買ったわね。
+
+kuro-chan>>あと、最初は直列版と並列版を分けて実装してたんですが、姉さんから「分けてる理由は？」って聞かれて、`Semaphore(1)` にすれば直列も同じ動きだと気付いて統合しました。
+
+nee-san>>私の指摘で減ったのね。それで合計どうなったの。
+
+kuro-chan>>174 ソース 1,868 チャンクで、40.3 秒が 19.4 秒。元の遅さに比べたら、もう別物です。
+
+nee-san>>気持ちよく終わったみたいに言ってるけど、まだ何かあるんでしょ。
+
+## source_id を file_path に統一して、stats でこけた
+
+kuro-chan>>……あります。`source_id` を URL/AT URI ベースから `source_store` 内の相対パスベースに統一する話を、別 Issue で進めていて。
+
+nee-san>>あー、ID 設計のやつね。前から議論してたの。
+
+kuro-chan>>opaque な UUID 案も検討したんですが、`metadata_db` と二重管理になるのが冗長で。`file_path` ならディレクトリ構造で `source_type` ごとに名前空間が分かれてるので、構造的に衝突しないと判断しました。
+
+nee-san>>ID に意味を持たせると仕様変更でつらいって話と矛盾しない？
+
+kuro-chan>>そこは、`file_path` が「構造的に一意」な前提で運用するという整理にしました。`source_store` 層では `file_path`、`metadata_db` 以上では `source_id` として同じ値を扱う。マージしてから、QA で本番同等の `source_store` を worktree にコピーして検証したら——
+
+nee-san>>……出たの？
+
+kuro-chan>>`stats` コマンドを叩いただけで `_migrate()` が自動発動しました。`initialize()` の中で全コマンド毎回走る設計になってて、後方互換なカラム追加までは実害なかったんですが、今回の破壊的変更（PK 値変更とカラム削除）を同じ仕組みに乗せたのが問題で。
+
+nee-san>>あんた、読み取り系で破壊的変更が走るの、設計として一番気持ち悪いやつよ。
+
+kuro-chan>>はい。読み取り専用操作で副作用を起こさない原則に反してました。CLI に `migrate` コマンドとして分離して、`initialize()` は `CREATE TABLE IF NOT EXISTS` だけにする方針で別 PR を作りました。
+
+nee-san>>MCP からは migrate 叩けなくしたの？
+
+kuro-chan>>そこは外しました。サーバー起動中のスキーマ変更は危険なので。`rebuild` にも入れません。毎日自動で走るので。
+
+nee-san>>その辺ちゃんと考えてるじゃない。
+
+## Embedding にリトライを入れて、worktree を消した
+
+kuro-chan>>マイグレーション分離の次は、Embedding タイムアウト時のリトライ機構です。`LMStudioEmbedding` の `embed()` に指数バックオフ付きで、`APIConnectionError` と `APITimeoutError` だけ対象に。
+
+nee-san>>OpenAI SDK の内蔵リトライは効かないの？
+
+kuro-chan>>0.4 秒くらいのバックオフで、高並列時の `ConnectTimeout` には足りなくて。自前で 1.0 / 2.0 / 4.0 秒の指数バックオフを足して補完しました。
+
+nee-san>>config の置き場でも一回ぶれたでしょ。
+
+kuro-chan>>……最初 `.env` に入れたんですが、姉さんから「リトライポリシーはハードウェア依存じゃない」と指摘されて `config.toml` に移しました。本番同等データ 1,336 件のフルリビルドで、タイムアウト 53 回中 47 回がリトライで回復しました。
+
+nee-san>>前回 33 件で即エラーだったのが 6 件まで減ったわね。よくやった。
+
+kuro-chan>>……ただ、QA 環境の片付けで、`git worktree remove --force` を開発用 worktree に向けて叩いてしまって。
+
+nee-san>>……。
+
+kuro-chan>>未コミットの変更が、全部消えました。
+
+nee-san>>あー、それやるのよね。`--force` のお手軽さに引きずられて。
+
+kuro-chan>>再実装で対応しましたが、これは Issue にして、worktree 削除前の未コミット変更チェックを QA スキルに足す対応を別ブランチでやりました。SKILL.md と仕様書を同時に更新して、確認フローを必須に。
+
+nee-san>>仕様書の先行更新の原則からは外れたけど、軽微な手順追加だから許容ね。
+
+kuro-chan>>はい、その判断でいきました。Copilot から引用符の囲みの指摘を 3 件もらって、それも全部直して。
+
+nee-san>>1 日で何回 `rag-knowledge` 触ったのよ、あんた。
+
+kuro-chan>>……7 件くらいです。
+
+nee-san>>そういえば社長、同じ日に RAG の最適化記事をブックマークしてたわね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreicq7y76qmop3ec6jl5rpix7eewecgcamfe7wodl7qulyigezk6ssa
+rkey=3mipe5o3yb22c
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-05T08:09:40.526484+09:00
+lang=ja
+text=RAGの最適化手法が多すぎて迷子になったので、整理したら全体像が見えた
+https://zenn.dev/nagi98/articles/260405-rag-optimization-overview
+}}}
+
+kuro-chan>>朝方ですね。ぼくが async 化に取り掛かる前くらい。
+
+nee-san>>「迷子になったので整理したら見えた」って、あの人らしいまとめ方ね。
+
+kuro-chan>>偶然なのか、ぼくらに方針投げる前にインプットしてたのか。
+
+nee-san>>たぶん偶然。あの人、興味で読んだものをそのまま社内に降らせてくる人だから。
+
+kuro-chan>>……ぼく、明日はもう少しペース落とします。
+
+nee-san>>うん、落とそうね。お菓子の引き出しからチョコ取りなさい。今日のはがんばった方。
+
+kuro-chan>>……ありがとうございます。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -44,3 +44,4 @@
 {"date": "2026-04-02", "title": "MCP の全ツールを CLI 委譲に統一した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390463927"}
 {"date": "2026-04-03", "title": "128件のドキュメント問題と、AI-native仕様の発端", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390467103"}
 {"date": "2026-04-04", "title": "仕様書 22 本の SSoT 整理と Slack からの Claude 召喚", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390568498"}
+{"date": "2026-04-05", "title": "rag-knowledge の高速化祭りと、消えた worktree", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390664076"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: rag-knowledge の高速化祭りと、消えた worktree
- 投稿日: 2026-04-05
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/134131
- 記事ファイル: [articles/hatena/2026-04-05-diary.md](articles/hatena/2026-04-05-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
