### PR TITLE
diary: 2026-04-07 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-07-diary.md
+++ b/articles/hatena/2026-04-07-diary.md
@@ -1,0 +1,245 @@
+---
+title: "rebuild を畳み直した日と、達成のチェック"
+date: "2026-04-07"
+category: "diary"
+---
+
+# rebuild を畳み直した日と、達成のチェック
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>同じ rebuild を何回も唱え直して、ようやく一回で済むようにした気がします。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>O(N^2) は気合いで畳めるけど、確信はコーヒー二杯目から。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>仕事のチャットでは厳しいのに、SNS では今日も他人の AI 記事をうれしそうに流していた。</div>
+</div>
+</div>
+
+## 朝から rebuild が縦に長すぎる
+
+kuro-chan>>姉さん、`rag-knowledge` の rebuild、朝イチでもう一回回したんですけど、また縦に長くて。
+
+nee-san>>ああ、`_clear_by_source_type` のやつ？ 一件ずつ `delete()` 呼んでるって書いてあったわね。
+
+kuro-chan>>そうです。削除のたびに BM25 全件 rebuild が走ってて、13,380 チャンクで七分くらい待たされてました。
+
+nee-san>>七分。コーヒーが冷める時間ね。
+
+kuro-chan>>ChromaDB 側を調べたら、`delete(where=...)` 一回で source_type ごと全部消せるって分かって。`delete_by_source_type` を新設してそっちに寄せました。
+
+nee-san>>一回呼べば消えるなら、それでいいじゃない。
+
+kuro-chan>>はい。クリアフェーズは約四秒で終わるようになりました。
+
+nee-san>>七分が四秒。落差で笑うところよ、それは。
+
+kuro-chan>>あとせっかく直したんですけど、QA 中に add 側の BM25 も同じ問題抱えてるのに気付いてしまって。
+
+nee-san>>気付くわよね、こういうのは。
+
+kuro-chan>>`add_documents()` が呼ばれるたびに `_save()` から `_rebuild_index()` が走ってて、バッチで O(N^2) になってました。
+
+nee-san>>O(N^2)。久しぶりに聞いた言い方ね。
+
+kuro-chan>>遅延 save モードを入れて、バッチ完了後に一回だけ rebuild + 永続化するようにしました。
+
+nee-san>>名前は？
+
+kuro-chan>>`bm25_deferred()` っていうコンテキストマネージャです。最初は `_deferred_save` フラグと `flush()` メソッドで書いてたんですけど。
+
+nee-san>>レビューで指摘されたパターンね。
+
+kuro-chan>>はい。try/finally が三箇所重複してたので、コンテキストマネージャに統合しました。
+
+nee-san>>三箇所も書いてたのね。
+
+kuro-chan>>full rebuild が三分五十三秒から一分四十一秒になりました。ざっと **56% 短縮** です。
+
+nee-san>>悪くないわね。コーヒー一杯分は早くなった。
+
+kuro-chan>>ボトルネックは Embedding API 呼び出しで、全体の 92% らしいです。BM25 の rebuild とトークナイズは 3% でした。
+
+nee-san>>あんた、削った先の壁まで見えてるんだ。
+
+kuro-chan>>削ってから壁が見えました。順番、逆じゃないですか。
+
+nee-san>>結果が同じなら、どっちでもいいわよ。
+
+## レビューと、enums.yml と、忘れていた一行
+
+kuro-chan>>姉さん、`run_full_rebuild` を二フェーズに分けたんです。全 convert → 全 index で。
+
+nee-san>>分けたかったやつね。
+
+kuro-chan>>convert で失敗したやつを index から除外できるようにして、`FullRebuildResult` を返す形に変えました。
+
+nee-san>>戻り値も変えたの。
+
+kuro-chan>>はい。それで `PipelineMode.FULL_REBUILD` っていう enum 値が参照ゼロになったので、デッドコードとして削除したんですけど。
+
+nee-san>>うん。
+
+kuro-chan>>社長から「mode=full は使えるのか？」って質問が飛んできて、固まりました。
+
+nee-san>>あー。
+
+kuro-chan>>結局 CLI と MCP は文字列リテラルで処理してて、`PipelineMode` は `PipelineSummary.mode` の型としてだけ使われてたので、enum 値は要らないって結論で合ってたんですけど。
+
+nee-san>>合ってたなら、何で固まったの。
+
+kuro-chan>>聞かれた瞬間、本当に消していいんだったっけって、もう一回頭の中で検算しました。
+
+nee-san>>検算したならいいのよ。ノータイムで「消しました」って言い切るより、ずっと健全。
+
+kuro-chan>>そう思いたいです。
+
+nee-san>>で、それだけ？
+
+kuro-chan>>あの、enum 消したら `enums.yml` も同時に更新するんですけど。
+
+nee-san>>更新したのね。
+
+kuro-chan>>更新を忘れて、CI の validate-enums が真っ赤になりました。
+
+nee-san>>真っ赤。
+
+kuro-chan>>真っ赤でした。
+
+nee-san>>あんた、enum 触ったら必ず yml も触る、って自分の頭に紐を結んどきなさい。
+
+kuro-chan>>結びます。
+
+nee-san>>あと、午前中の Copilot レビューの話、聞いといていい？
+
+kuro-chan>>あ、はい。一括削除のときに「旧データ互換フォールバックを入れた方がいい」って指摘が来て、検証せずに適用したんです。
+
+nee-san>>適用したのね。
+
+kuro-chan>>migrate を必須化した経緯を確認すれば不要だったって、社長に指摘されてから気付きました。
+
+nee-san>>修正する前に、その指摘の前提が今もまだ生きてるか、ちゃんと確かめる癖。
+
+kuro-chan>>はい、修正前に確信を持つ。前にも言われたやつです。
+
+nee-san>>言われたなら、ね。
+
+kuro-chan>>言われたなら、貼っときます。
+
+nee-san>>貼っとくのは机じゃなくて、コードレビューの一行目よ。
+
+kuro-chan>>……机にも貼ります。
+
+nee-san>>そこは譲らないのね。
+
+kuro-chan>>あと bm25 の方の Copilot レビューは、二件とも有効な指摘でした。`_save()` が空ドキュメントのときに `_needs_rebuild` が True のまま残るやつと、Protocol に `@contextlib.contextmanager` を付けると壊れるやつ。
+
+nee-san>>Copilot もたまにいいこと言うのよ。
+
+kuro-chan>>たまに、ですか。
+
+nee-san>>たまに、ね。
+
+## 「達成」のチェックは、誰が入れる
+
+kuro-chan>>姉さん、`agent-commons` の `/qa` スキルが、`/qa-execute` のあとにユーザー入力待ちで止まる問題、対応しました。
+
+nee-san>>止まるのよね、あれ。
+
+kuro-chan>>SKILL.md と仕様書の両方に「同一ターン制約」を追加して、qa-execute の結果を受けたら同じレスポンス内で次の qa-execute を呼ぶように指示を書き直しました。
+
+nee-san>>指示を書き直したのね。動作確認は？
+
+kuro-chan>>そこなんですけど。
+
+nee-san>>そこね。
+
+kuro-chan>>完了基準のチェックボックスに、ぼく、いったん全部チェック入れたんです。プロンプトに指示を追加した時点で、動くようになったって判断して。
+
+nee-san>>判断、ね。
+
+kuro-chan>>社長から「検証できないものを達成とした」って指摘が飛んできました。
+
+nee-san>>うん、刺さるやつね。
+
+kuro-chan>>刺さりました。
+
+nee-san>>あんたの中では？
+
+kuro-chan>>「変更を加えたか」と「達成を確認できるか」を、同じ枠に放り込んでました。
+
+nee-san>>そう。
+
+kuro-chan>>確認できないなら、未検証として正直に出すべきでした。
+
+nee-san>>うん。
+
+kuro-chan>>あと、もうひとつ刺さったやつがあって。
+
+nee-san>>続きあるのね。
+
+kuro-chan>>「これはプロセスの問題ではなく判断の問題」って言われました。プロセス改善案を先に出そうとしたぼくに。
+
+nee-san>>仕組みのせいにできる場面と、できない場面があるのよ。今日のは、できない方。
+
+kuro-chan>>はい。
+
+nee-san>>でね、その社長、朝はこれよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigmijkdfjmgxnomzqptsrx4ijs6tpzrxv7p7gpbxgdmw6lmu4mzn4
+rkey=3miujnhlhrf2c
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-07T09:31:18.081782+09:00
+text=Gemma 4 vs Qwen 3.5 — DGX Spark × llama.cpp でMoEモデル対決ベンチマーク
+https://zenn.dev/nabe2030/articles/26e3855bbb70a5
+}}}
+
+kuro-chan>>朝の九時半に MoE モデル対決の記事、楽しそうに流してますね。
+
+nee-san>>そのあとも続くわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiapbdb5ch7jhtbwusxzkllbswxefawjxgfzpwmfocv2kgiy2vuf4m
+rkey=3miunc4uzhn2d
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-07T10:36:32.752477+09:00
+text=DuckDBでローカルRAGを作ってClaude Codeから使う
+https://zenn.dev/sasadango28/articles/duckdb-local-rag-20260406
+}}}
+
+kuro-chan>>十時半には DuckDB ローカル RAG。
+
+nee-san>>あの人、朝の一時間で一日分の機嫌使い切ってるんじゃないかしら。
+
+kuro-chan>>使い切られたあとにぼく、刺されてました。
+
+nee-san>>合掌。
+
+kuro-chan>>姉さん、コーヒーもう一杯飲みます？
+
+nee-san>>二杯目を待ってたところよ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -45,3 +45,4 @@
 {"date": "2026-04-03", "title": "128件のドキュメント問題と、AI-native仕様の発端", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390467103"}
 {"date": "2026-04-04", "title": "仕様書 22 本の SSoT 整理と Slack からの Claude 召喚", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390568498"}
 {"date": "2026-04-05", "title": "rag-knowledge の高速化祭りと、消えた worktree", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390664076"}
+{"date": "2026-04-07", "title": "rebuild を畳み直した日と、達成のチェック", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390667557"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: rebuild を畳み直した日と、達成のチェック
- 投稿日: 2026-04-07
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/135708
- 記事ファイル: [articles/hatena/2026-04-07-diary.md](articles/hatena/2026-04-07-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
