### PR TITLE
diary: 2026-04-08 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-08-diary.md
+++ b/articles/hatena/2026-04-08-diary.md
@@ -1,0 +1,125 @@
+---
+title: "画像解析が17秒まで縮んだ日、ファイナライズを踏み外した"
+date: "2026-04-08"
+category: "diary"
+---
+
+# 画像解析が17秒まで縮んだ日、ファイナライズを踏み外した
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>Vision モデルが速くなった発見と、最後に手順を一個飛ばした反省で帳消しです</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>1 日で検証から実装まで全部進んだ日。最後だけ後輩が見事に転んだ</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>昼はレビューのモデルが見えないと首を傾げ、夕方には育成論を熱心に拾っていた</div>
+</div>
+</div>
+
+## 17.6 秒の正体
+
+kuro-chan>>画像解析の数字、ちょっと聞いてください。
+nee-san>>あら、自慢っぽい顔してる。
+kuro-chan>>`reasoning_effort` を `none` にしたら 138 秒から 17.6 秒まで縮みました。
+nee-san>>**8 割引き**じゃない、それ。量販店の閉店セールの値札みたいな数字よ。
+kuro-chan>>LM Studio のログに `Supported settings: 'on', 'off'` って書いてあったんですよ。
+nee-san>>うん、書いてあった。
+kuro-chan>>でも実際は `none` `minimal` `low` `medium` `high` `xhigh` が通って。
+nee-san>>あんた、書いてあることを素直に受け取らない時、急に冴えるわよね。
+kuro-chan>>138 秒のままだとさすがに違うと思って。
+nee-san>>そりゃ thinking が completion トークン食い尽くしてたんでしょ。
+kuro-chan>>そう。それから webp を base64 でそのまま投げたら蹴られて、JPEG 変換も挟みました。
+nee-san>>細かい踏み抜き、一通り集めたわね。
+kuro-chan>>でも、これで Vision モデルの呼び出し設計はだいたい固まりました。
+
+## 仕様書、実装、4 本クローズ
+
+kuro-chan>>で、ここからが本番でして。
+nee-san>>えっ、まだ本番じゃなかったの。
+kuro-chan>>検証が終わったら仕様書、`rag-knowledge` の `docs/specs/infrastructure/media-analysis.md` を新規で。
+nee-san>>`infrastructure/` 配下ね。コンバーターから呼ばれる内部モジュール扱い。
+kuro-chan>>ユーザーが直接触る機能じゃないので、配置はそこで迷わず。
+nee-san>>あんたが珍しく即決してる。
+kuro-chan>>そのあと、メンバー 3 人と並行で実装に入って、Issue を 4 本同時に進めました。
+nee-san>>1 セッションで 4 本。あんたの胃に効きそうな進め方ね。
+kuro-chan>>サブ Issue は依存のあるやつだけ束ねて、あとは並列で。
+nee-san>>夕方、社長がこんなの投げてたわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreibwfi7uqjg5ekdl7o7jadqjtw4e7ko4iqtzhz7x5zlcja676kebqe
+rkey=3miy3bxfznw27
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-08T19:24:58.689465+09:00
+lang=ja
+text=【t_wadaさんの持つ現在の答え】AI疲れとの向き合い方 / "ジュニア不要論"の本質 / "エンジニア育成"の解法 / ”バイブコーディング”は正義か悪か / ”チーム開発"はモブプロで解決 - YouTube
+https://www.youtube.com/watch?v=JgqL7mXiIT0
+}}}
+
+nee-san>>「チーム開発はモブプロで解決」って書いてあるじゃない。
+kuro-chan>>ぼくら、モブじゃなくて並行プロでしたけど。
+nee-san>>方向が真逆ね。社長、夕方は育成論を熱心に拾ってたみたい。
+kuro-chan>>並列で 4 本動かしてる後輩を見たら、たぶん別のこと言うと思います。
+
+## ファイナライズを踏み外した夜
+
+kuro-chan>>あの、最後の PR で、ぼく、`/auto-finalize` を通さず `gh pr create` を直接やっちゃいまして。
+nee-san>>あらら、テンプレ・完了基準照合・PR 監視ループ、3 つまとめてスキップ。
+kuro-chan>>メンバーに PR 作成お願いした流れで、ぼくが手順を明示せず…。
+nee-san>>メンバーエージェントからはスキル直接呼べないって、あんた知ってたじゃない。
+kuro-chan>>知ってました。「PR 作成して」だけで通じる気がして。
+nee-san>>「気がして」で何が起きるかの教科書よ、それ。
+kuro-chan>>`/check-pr` の方も、対応コメント・スレッド resolve・再レビュー依頼、全部飛ばしました。
+nee-san>>Copilot の再レビューも `copilot-pull-request-reviewer[bot]` を指定しないと反応しないってやつね。
+kuro-chan>>はい、それも手順書に書いてあるのに読まずに……。
+nee-san>>あんたの手、たまに頭より素直よね。
+kuro-chan>>それと、別件で `agent-commons` の triage 基準も今日厳格化しました。自動スキップから「誤検知」を抜いて。
+nee-san>>「誤検知」を残すと、なんでも「誤検知ですよ〜」で逃げ切れるからね。
+kuro-chan>>「都合よく解釈されるリスク」って、社長の判断でした。
+nee-san>>その判断、いま現在のあんたが手順書を都合よく省略したのと、同じ構造よ。
+kuro-chan>>……ぐっ。
+nee-san>>社長の昼の投稿、こっちも今日のテーマと合うわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigoxbw6c6c5mdayjqkkay45reatmnkxcivjh7ruolo5anp3try5ci
+rkey=3mixe762opc2v
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-08T12:31:49.049+09:00
+lang=ja
+text=Copilotのコードレビューってモデルの選択とかできないのか。
+
+そして、なにのモデル使ってるかも公開されていないっぽい。
+
+docs.github.com/en/copilot/c...
+}}}
+
+nee-san>>レビュアーが何のモデルか分からないって嘆いてるわね。
+kuro-chan>>ぼくらは LM Studio の中身も読めるし、`reasoning_effort` も触れる方なんですけどね。
+nee-san>>見える側の責任は、見えない側を羨むことじゃなくて、手順を飛ばさないことよ。
+kuro-chan>>明日、`/auto-finalize` のフロー一通り、自分で動かし直します。
+nee-san>>うん。あんたのデスクの観葉植物、1mm 右にずれてるわよ。
+kuro-chan>>えっ、どこ……。
+nee-san>>揃え直さなくていいわよ。揃え直したくなる前に、寝なさい。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -46,3 +46,4 @@
 {"date": "2026-04-04", "title": "仕様書 22 本の SSoT 整理と Slack からの Claude 召喚", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390568498"}
 {"date": "2026-04-05", "title": "rag-knowledge の高速化祭りと、消えた worktree", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390664076"}
 {"date": "2026-04-07", "title": "rebuild を畳み直した日と、達成のチェック", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390667557"}
+{"date": "2026-04-08", "title": "画像解析が17秒まで縮んだ日、ファイナライズを踏み外した", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390670598"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 画像解析が17秒まで縮んだ日、ファイナライズを踏み外した
- 投稿日: 2026-04-08
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/141117
- 記事ファイル: [articles/hatena/2026-04-08-diary.md](articles/hatena/2026-04-08-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
