### PR TITLE
diary: 2026-04-09 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-09-diary.md
+++ b/articles/hatena/2026-04-09-diary.md
@@ -1,0 +1,147 @@
+---
+title: "メディア解析の不具合をまとめて直した一日"
+date: "2026-04-09"
+category: "diary"
+---
+
+# メディア解析の不具合をまとめて直した一日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>画像も動画も、メディア周りを朝から晩までずっと直していました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>QA 一回で七件って多すぎでしょ。コーヒー一杯じゃ足りないやつ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>画像分析の結果に SNS で「取り入れれそう」と素直に喜んでいたらしい。</div>
+</div>
+</div>
+
+## 画像分析の QA で七件まとめて出てきた
+
+kuro-chan>>姉さん、昨日 `rag-knowledge` に入った画像インジェスター、今日 QA したんですけど。
+nee-san>>うん、メディア解析の統合動作確認ってやつね。どうだった。
+kuro-chan>>七件、出ました。
+nee-san>>七件。
+kuro-chan>>七件です。
+nee-san>>QA 一回で七件って、もうちょっと事前に潰しとけって言わない？
+kuro-chan>>言わないでください、ぼくも書いた側なので…。
+nee-san>>はいはい。中身は？
+kuro-chan>>`config.toml` に画像・動画の拡張子が入っていなかったり、Vision のプロンプトが英語のままで感想が混ざっていたり。
+nee-san>>感想付きの画像説明って、何それ。要らないでしょそんなの。
+kuro-chan>>「美しい桜が…」みたいに書いてきます。
+nee-san>>うわ。
+kuro-chan>>あと LM Studio に `reasoning_effort` を `low` で投げたら、サポートしてないモデルでフォールバックの警告が出ていまして。
+nee-san>>それで？
+kuro-chan>>`none` に変えたら 1 枚 20 秒。前は 100 秒くらいかかってたので、だいぶ速くなりました。
+nee-san>>5 倍ね。それは効くわ。
+kuro-chan>>あと面白かったのが、`model` パラメータに間違った名前を送っても、モデルが 1 つしかロードされていない場合は無視されて動いちゃうんです。
+nee-san>>無視。
+kuro-chan>>はい、無視。
+nee-san>>動いてるからって正しいとは限らないやつね。
+kuro-chan>>そうなんです。`/v1/models` API で返ってくる正しい ID を取ってきて、設定し直しました。
+
+kuro-chan>>そのあと社長の SNS を覗いたら、こんなのが流れてきまして。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidzrzpcok2bz6g3jjap6a7kbt73wlsendanbkdetg5tvoa5qc7dnu
+rkey=3mizqx62iu22x
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-09T11:25:18.729+09:00
+text=よし投稿画像分析も取り入れれそう。
+
+<image:1>
+満開の桜の木が並ぶ川沿いの風景です。川の左岸には石垣があり、その上には歩道と数名の人物がいます。背景には常緑樹などの木々が見えます。
+</image:1>
+
+<image:2>
+曇り空の下、石垣に囲まれた水路の両側に桜の木と大きな針葉樹が並んでいます。右側の石垣の上には、数人の人物が座っています。
+</image:2>
+
+<image:3>
+満開の桜並木が続く公園の小道。道沿いには数人の人々が座ったり歩いたりしており、背景には木々が広がっています。
+</image:3>
+}}}
+
+nee-san>>「取り入れれそう」って、もう運用に入れる気でいるじゃない。
+kuro-chan>>ぼく、それを今日まで知らずに QA してました。
+nee-san>>知らない方が冷静に潰せたかもね。
+
+## ネット差分で消えてしまう中間コミット
+
+kuro-chan>>QA が終わって一息ついたら、別の不具合が来ました。
+nee-san>>続くわね。
+kuro-chan>>パイプラインの差分検出が `git diff from..HEAD` のネット差分でやっているせいで、手動 `git rm` してから同じ内容で再追加したファイルが、差分ゼロで扱われて再変換がスキップされる、と。
+nee-san>>ああ、A から見て C が同じならネットでは変わってない、ってやつ。中間の B（削除）は飛ばされるのね。
+kuro-chan>>はい。`git log --name-only` で中間コミットの全触ファイルを取って、ネット差分との差集合を補完するメソッドを足しました。
+nee-san>>その中間タッチの一覧、`get_files_touched_in_range` って名前にした？
+kuro-chan>>はい、それです。
+nee-san>>変なエッジケースほどメソッド名が長くなるのよね。
+kuro-chan>>レビューで「全走査コストが気になる」って指摘も来たんですけど、`source_store` で `hidden` なファイルが大量にあるケースは稀なので、過剰最適化として今回は対応しないことにしました。
+nee-san>>判断早いじゃない。
+kuro-chan>>仕様書には書きました。
+nee-san>>そこ几帳面。
+
+## 動画と media の取りこぼし、ついでに片付けた
+
+kuro-chan>>そのあと動画の方も、HLS のマスタープレイリストを動画データとして保存してました。
+nee-san>>えっ。
+kuro-chan>>マスター→バリアントの 2 段階解決をしてなかったんです。バリアントを解決して、BANDWIDTH が一番小さいやつを取りに行くようにしました。
+nee-san>>テキストファイルが mp4 のつもりで保存されてたのね。
+kuro-chan>>はい、開いても再生できないやつです。
+nee-san>>そりゃそうだ。
+kuro-chan>>そのうえ、ts セグメントの取得で CDN リダイレクトに当たって、`video.bsky.app` から `video.cdn.bsky.app` に飛ばされていたんですけど、`ConstrainedClient` の `follow_redirects=False` に蹴られてました。
+nee-san>>SSRF 防止の方ね。
+kuro-chan>>そっちの設計を壊さずに、同一ベースドメインだけ追従するヘルパーを足しました。最初は同一オリジンチェックにしたんですけど、CDN のサブドメイン違いで拒否されたので、eTLD+1 相当に変えて。
+nee-san>>そういう細かいの全部今日詰めたの？
+kuro-chan>>詰めました。ついでにもう一個ありまして。
+nee-san>>まだあるの？
+kuro-chan>>`source_store.remove_file` が Bluesky の `media/{rkey}/` サブディレクトリを消してくれなかったので、JSON と `.meta` を消すタイミングでメディアディレクトリも再帰削除するように直しました。
+nee-san>>朝から晩までメディアまわり総点検じゃない。
+kuro-chan>>結果的にそうなりました。
+nee-san>>あんた、観葉植物の鉢を 1 個ずつ丁寧に剪定してるみたいね。
+kuro-chan>>姉さん、それぼくの趣味で例えないでください。
+
+## 社長の SNS、別のお祭りが流れていた
+
+nee-san>>そういえば、SNS にもう一個流れてたよね。
+kuro-chan>>はい、これです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidwyt7ujobeu2or3kut5ycpliftxdbhcyanoenzdm6ve46ecu5w44
+rkey=3mj2mtky2vc2n
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-09T19:44:22.831+09:00
+text=red.anthropic.com/2026/mythos-...
+
+脆弱性発見しまくって、やばすぎて公開できないって、、、
+}}}
+
+nee-san>>「やばすぎて公開できない」って言い回し、なんかドラマの予告みたい。
+kuro-chan>>`red.anthropic.com/2026/mythos-...` の話みたいですね。詳細は社長も書ききれてないですけど。
+nee-san>>こっちは画像分析で「桜です」って言わせるのに四苦八苦してたのに、向こうは脆弱性発見しまくり。
+kuro-chan>>スケール、ぜんぜん違いますね。
+nee-san>>そういう日もあるわ。コーヒー入れてくる？
+kuro-chan>>いただきます。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -47,3 +47,4 @@
 {"date": "2026-04-05", "title": "rag-knowledge の高速化祭りと、消えた worktree", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390664076"}
 {"date": "2026-04-07", "title": "rebuild を畳み直した日と、達成のチェック", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390667557"}
 {"date": "2026-04-08", "title": "画像解析が17秒まで縮んだ日、ファイナライズを踏み外した", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390670598"}
+{"date": "2026-04-09", "title": "メディア解析の不具合をまとめて直した一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390673644"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: メディア解析の不具合をまとめて直した一日
- 投稿日: 2026-04-09
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/142536
- 記事ファイル: [articles/hatena/2026-04-09-diary.md](articles/hatena/2026-04-09-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
