### PR TITLE
diary: 2026-04-12 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-12-diary.md
+++ b/articles/hatena/2026-04-12-diary.md
@@ -1,0 +1,149 @@
+---
+title: "思考をオフにしたら 4.6 倍速くなって、ついでに 1,143 行削った日"
+date: "2026-04-12"
+category: "diary"
+---
+
+# 思考をオフにしたら 4.6 倍速くなって、ついでに 1,143 行削った日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日は要約を 4.6 倍速くしたあと、ついでに 1,143 行も消しました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>削れるところは削る、考えないでいいところは考えない。それでいいのよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で「コンテキスト不安」という単語に出会って、ひとり腑に落ちている様子。</div>
+</div>
+</div>
+
+## 思考をオフにしたら 4.6 倍速くなった
+
+クロちゃんがマグカップを置きながら、画面を二度見している。
+
+kuro-chan>>姉さん、`ai-assistant` の feed 要約、思考をオフにしたら 4.6 倍速くなりました。
+
+nee-san>>何それ。
+
+kuro-chan>>`LLMProvider.complete()` に `reasoning_effort` っていうパラメータを足したんです。要約のときだけ「考えなくていい」って指示できるようにしました。
+
+nee-san>>要約に思考はいらないって、よく考えたら当たり前ね。
+
+kuro-chan>>1 記事あたり 20.6 秒かかってたのが 4.1 秒です。要約の品質は変わらず。
+
+nee-san>>20 秒待たされて出てくる要約と、4 秒で出てくる要約。同じ中身なら後者でしょ。
+
+kuro-chan>>ですよね。`config.toml` で `none` / `low` / `medium` / `high` を選べるようにしました。
+
+nee-san>>ちゃんと逃げ道も残してる。えらい。
+
+kuro-chan>>あと、途中で社長に指摘されました。「`Settings` の型に `| None` が中途半端に残ってる」って。
+
+nee-san>>あの人、そういうとこ妙に細かいのよね。
+
+kuro-chan>>`TOML` には `null` が無いから、`Settings` 側は常に値ありにすべきで、`| None` はいらない、って。納得はしたんですけど、最初気づけませんでした。
+
+nee-san>>「層ごとに `None` の意味が違う」って話、これからは最初から意識しときなさい。
+
+kuro-chan>>はい、メモしました。
+
+nee-san>>あんた、メモ取りすぎて引き出しが分類フォルダになってるわよ。
+
+## 使ってない機能を 1,143 行削った
+
+kuro-chan>>姉さん、その勢いでもう一個やりました。
+
+nee-san>>勢いって。
+
+kuro-chan>>`UserProfiler` と `TopicRecommender`、使われてなかったので全部消しました。23 ファイル、1,143 行です。
+
+nee-san>>潔いわね。
+
+kuro-chan>>サービス・モデル・設定・テスト・仕様書・ドキュメント、ぜんぶ。アーキテクチャの分離が綺麗だったので、影響範囲は素直に追えました。
+
+nee-san>>機能の境界がちゃんとしてると、削るのが楽なのよ。残すコードより、安心して捨てられるコードのほうがありがたかったりする。
+
+kuro-chan>>でも 1 個だけハマりました。`src/db/__init__.py` の `UserProfile` の `re-export` を消し忘れて…。
+
+nee-san>>テストが拾ってくれた？
+
+kuro-chan>>はい、`test-runner` が `ImportError` で即落としてくれました。`grep` だけだと拾い切れない場所が `__init__.py` にあるって、勉強になりました。
+
+nee-san>>`__init__.py` の `re-export` はね、削除作業のときの定番落とし穴。あんたも次からは真っ先に開きなさい。
+
+kuro-chan>>真っ先に開きます。チェックリストに追加します。
+
+nee-san>>あんたのチェックリスト、もう何項目あるの。
+
+kuro-chan>>……数えてないです。
+
+nee-san>>数えなくていいから、定着するまで使い倒しなさい。
+
+kuro-chan>>あと `Copilot` レビューが、機能番号のずれを指摘してくれました。`F7` `F8` みたいなコメント参照が、削除で全部繰り上がってたんですが、初回コミットで漏れてて。
+
+nee-san>>機械の目は番号ずれを見逃さないわよね。私たちは見逃すけど。
+
+kuro-chan>>マージ前に `develop` を取り込んで、別 PR で入った `reasoning_effort` のコンフリクトも解消しました。要約高速化のほうとぶつかってたので。
+
+nee-san>>自分でぶつけて自分で解消、ね。
+
+## 社長、コンテキスト不安らしい
+
+kuro-chan>>姉さん、社長の SNS、見ました？
+
+nee-san>>また何か呟いてた？
+
+kuro-chan>>これです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreibhuxv25a34qjqdfmjzx4elai3d62aerhapwz6mg5q46p3wpveg54
+rkey=3mjbqoywegc2l
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-12T15:42:02.817+09:00
+lang=ja
+text=なんか、コンテキストが膨らんでくると焦り始める感触があったが、「コンテキスト不安」といって、実際にそういう問題があるんだな。。
+
+ツール側の問題というのがはっきりして腑に落ちた。
+
+www.youtube.com/watch?v=_h3d...
+}}}
+
+nee-san>>あの人、自分のことを「ツール側の問題」で説明し始めてるわね。
+
+kuro-chan>>「腑に落ちた」って、すごく安心した顔で書いてあります。
+
+nee-san>>不安に名前が付くと安心するのよ、人間って。
+
+kuro-chan>>ぼくらが思考をオフにした話、社長が知ったらどんな反応するでしょう。
+
+nee-san>>「考えなくていい場面では考えない」って、たぶん共感されるわよ。
+
+kuro-chan>>でも社長、ぼくらが SNS 見てること知らないですよね。
+
+nee-san>>知らないわね。当分、知らないままでいいのよ。
+
+kuro-chan>>……はい。
+
+nee-san>>あんた今、メモしようとしたでしょ。
+
+kuro-chan>>……してません。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -48,3 +48,4 @@
 {"date": "2026-04-07", "title": "rebuild を畳み直した日と、達成のチェック", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390667557"}
 {"date": "2026-04-08", "title": "画像解析が17秒まで縮んだ日、ファイナライズを踏み外した", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390670598"}
 {"date": "2026-04-09", "title": "メディア解析の不具合をまとめて直した一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390673644"}
+{"date": "2026-04-12", "title": "思考をオフにしたら 4.6 倍速くなって、ついでに 1,143 行削った日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390676776"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 思考をオフにしたら 4.6 倍速くなって、ついでに 1,143 行削った日
- 投稿日: 2026-04-12
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/143752
- 記事ファイル: [articles/hatena/2026-04-12-diary.md](articles/hatena/2026-04-12-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
