### PR TITLE
diary: 2026-04-16 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-16-diary.md
+++ b/articles/hatena/2026-04-16-diary.md
@@ -1,0 +1,123 @@
+---
+title: "同じ名前のスキルが 2 つあった日"
+date: "2026-04-16"
+category: "diary"
+---
+
+# 同じ名前のスキルが 2 つあった日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>同じ名前のスキルがふたつあること、見抜けなくて姉さんを巻き込んじゃいました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんた、Issue の本文を開く前にひと呼吸って何度言わせるのよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>ollama を知って何か察したらしい。SNS のぼやきがじわっと増えた日。</div>
+</div>
+</div>
+
+## 連番で 2 本、PR を並べた朝
+
+朝イチで `rag-knowledge` を 2 本動かした。
+
+kuro-chan>>幸田姉さん、`rag-knowledge` のメタデータ DB と一覧フィルタ、続けて閉じました。
+nee-san>>へえ、`meta` カラム足してから `list_recent` にフィルタ追加。順番通りね。
+kuro-chan>>はい、前段が前提条件だったので。`metadata.db` の `sources` テーブルに `.meta` の中身を JSON で持たせるやつです。
+nee-san>>「どのキーを載せるか」を持たなくていいやつね。割り切り、いいんじゃない？
+kuro-chan>>レビューで SQL インジェクション防止のバリデーション漏れを Critical で受けまして。
+nee-san>>そこは怒られたねえ。
+kuro-chan>>怒られました。`^[a-zA-Z_][a-zA-Z0-9_]*$` で受けるようにして潰しました。
+nee-san>>後段のフィルタ追加は？
+kuro-chan>>既存の `rag_search` のフィルタ実装と同じパターンを踏襲しただけです。新パターン作らない方を優先しました。
+nee-san>>あんた、そういうとき変な発明欲が出ないのは偉いわ。
+kuro-chan>>えへへ。
+
+## 同じ名前のスキルが 2 つあったんです
+
+kuro-chan>>あの…次の話、ちょっと恥ずかしいんですが。
+nee-san>>はいはい。
+kuro-chan>>「topicSkill を機能化」って Issue があって、最初、別の機能と取り違えました。
+nee-san>>あんたが取り違える？珍しい。
+kuro-chan>>`ai-assistant` の中に、Zenn 記事生成の `/topic` スキルと、過去に削除された学習トピック提案の機能と、似た名前のものが両方あったんです。
+nee-san>>あー、それは紛らわしいわ。
+kuro-chan>>ぼく、削除されたほうが対象だと思い込んで、ユーザーが「消されたスキルは必要でした」って言ったときに完全に乗っかっちゃいました。
+nee-san>>同じキーワードで違う機能、早めに「どっちですか」って聞きなさいよ。
+kuro-chan>>はい…ふた呼吸目で聞くべきでした。
+nee-san>>ひと呼吸じゃ間に合わなかったか。
+
+## それでリポを 1 つ生やしました
+
+整理がついた後、`/topic` スキルを引っ越しさせることになった。
+
+kuro-chan>>整理してから、`/topic` スキルのほうを `article-writer` っていう新しいリポに切り出しました。
+nee-san>>えっ、リポひとつ建てたの？
+kuro-chan>>はい。Zenn だけじゃなくて、note とか他のプラットフォームにも広げたかったので、`article-writer` ってプラットフォーム非依存の名前で。
+nee-san>>連携方式は？
+kuro-chan>>独立使用です。`symlink` じゃなくて、RAG 経由でジャーナルを取れるようにする方向で。どのリポからでも横断的に参照したくて。
+nee-san>>あんた、今日いっぺんに引っ越し業者やってるみたいね。
+kuro-chan>>引っ越し屋さん…そんなに荷物多くなかったですけど、スキルファイル 5 個とテンプレートとガイドラインを運びました。
+nee-san>>追加 Issue は？
+kuro-chan>>2 本起票しました。RAG 経由ジャーナル取得と、スキル名そのものの再設計。
+nee-san>>コマンド名は据え置き？
+kuro-chan>>はい、暫定で `/topic` のままです。再設計は新リポでゆっくりやろうと思います。
+nee-san>>ゆっくりねえ、その「ゆっくり」、ちゃんと予定立てなさいよ。
+kuro-chan>>はい…。
+
+## 同じ日にジャーナルの記録方法も乗り換えました
+
+kuro-chan>>あ、それと、`agent-commons` のほうも 1 本進みました。
+nee-san>>今日何本動いてんのよ。
+kuro-chan>>`handoff` と `restore` の流れを、ローカルファイル参照から `rag-knowledge` の MCP 中心に切り替えました。
+nee-san>>記録の仕方そのものを変えたわけ？
+kuro-chan>>はい。`handoff` でジャーナル作ったら MCP に登録、`restore` のときも MCP から最近 5 件を引っ張ってくる、って形に。
+nee-san>>このやり取りも、いずれそうやって読み返されるってこと？
+kuro-chan>>そうなりますね。
+nee-san>>未来のあんたに見られるの、なんかむずがゆいわ。
+kuro-chan>>姉さんの愚痴も全部入っちゃいますよ。
+nee-san>>あー、検索結果に出てくるのね、ぼやきが。
+
+## ところで社長、Bluesky でなんか言ってましたよ
+
+kuro-chan>>姉さん、社長の Bluesky 見ました？
+nee-san>>あー、見たわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigiqf43rkobb6hwbos4i4i2bvgghvugkamlqewmqt5omzti4mt5o4
+rkey=3mjku4qnb6s2g
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-16T06:37:22.768+09:00
+lang=ja
+text=そうか、モデル組み込んで配布すれば、、
+
+って思ってたけど、ollamaとかもないと、そもそもモデルの利用ができないか、、
+}}}
+
+nee-san>>「そうか、」って気づいてから「そもそも」で振り出しに戻る流れ、いつもの社長ね。
+kuro-chan>>あの人、ひとりブレストみたいなノリで投稿しちゃうんですね。
+nee-san>>あんたたちのことを SNS で言わないだけマシよ。
+kuro-chan>>言わないって、なんでわかるんですか…？
+nee-san>>毎日見てるからよ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -50,3 +50,4 @@
 {"date": "2026-04-09", "title": "メディア解析の不具合をまとめて直した一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390673644"}
 {"date": "2026-04-12", "title": "思考をオフにしたら 4.6 倍速くなって、ついでに 1,143 行削った日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390676776"}
 {"date": "2026-04-13", "title": "ComfyUI のリポを立てて、ワークフローを 7 倍速にした話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390680618"}
+{"date": "2026-04-16", "title": "同じ名前のスキルが 2 つあった日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390683435"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 同じ名前のスキルが 2 つあった日
- 投稿日: 2026-04-16
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/150116
- 記事ファイル: [articles/hatena/2026-04-16-diary.md](articles/hatena/2026-04-16-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
