### PR TITLE
diary: 2026-04-19 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-19-diary.md
+++ b/articles/hatena/2026-04-19-diary.md
@@ -1,0 +1,162 @@
+---
+title: "品質チェックを 3 リポに撒いてログの穴も塞いだ日"
+date: "2026-04-19"
+category: "diary"
+---
+
+# 品質チェックを 3 リポに撒いてログの穴も塞いだ日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ログ周りの抜け穴を 1 日かけて塞いだら、頭の中も穴だらけになりました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>3 つのリポに同じ workflow を撒く日。撒き終わってからのバタつきが本番。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>「要件漏れはめちゃくちゃ出てくるもんだなぁ」と今日も SNS でうんざりしていた。</div>
+</div>
+</div>
+
+## 品質チェックを横展開した日
+
+kuro-chan>>姉さん、まず `shared-workflows` で reusable workflow を組んで、それを `rag-knowledge` と `ai-assistant` に同じ日に展開しました。
+
+nee-san>>3 リポ同日横展開。やる気あるじゃない。
+
+kuro-chan>>テスト・lint・型チェック・markdownlint の 4 ジョブを並列に走らせて、それぞれを branch protection の必須チェックに指定できる作りにしました。
+
+nee-san>>並列ね。1 個コケたら全部止まる作りより、独立で見られる方が後で楽。
+
+kuro-chan>>workflow_call の inputs のキー名は、最初ハイフン区切りで書いてたんですが、Copilot レビューで「expression でハイフンが減算と解釈されるリスクがあります」って指摘されてアンダースコアに直しました。
+
+nee-san>>あー、`${{ inputs.install-command }}` がぱっと見おかしく見えるやつね。覚えとくと得する話。
+
+kuro-chan>>あと、`rag-knowledge` の方で `install_command` を `uv sync` から `uv sync --no-group with-mineru` に変えました。CI は GPU 無しなので、MinerU と PyTorch CUDA がインストールできなくて止まるんです。
+
+nee-san>>GPU 前提のグループ、CI で巻き込まれるパターンね。ローカルと CI の差で必ず一度はやるやつ。
+
+kuro-chan>>……で、ここからが本題なんですけど。
+
+nee-san>>来た。
+
+kuro-chan>>branch protection rule のチェック名、最初 `Lint` で登録したんですよ。そしたら全 PR がマージブロックされて。
+
+nee-san>>名前ずれ？
+
+kuro-chan>>はい。reusable workflow の caller job 名 `quality` がプレフィックスとして付くので、実際の名前は `quality / Lint` でした。
+
+nee-san>>……それ、CI を 1 回走らせてから登録する方が安全よ。GitHub 側の自動補完が効くから。
+
+kuro-chan>>そうですよね。次からはそうします。
+
+nee-san>>「次から」じゃなくて、手順書に書いときなさい。3 リポ目で同じこと繰り返してたでしょ。
+
+kuro-chan>>……はい。
+
+## ログの穴と、既存問題のスキップ癖
+
+kuro-chan>>並行で `rag-knowledge` のログまわりも直してました。`RAG_LOG_DIR` を設定してもログファイルに `rag.server` のログが残らない問題があって。
+
+nee-san>>あれ、設定したら出るはずって話だったやつ？
+
+kuro-chan>>はい。最初は uvicorn の dictConfig がロガーを壊してるんだと思ったんですが、デバッグダンプ取ったら 2 層構造でした。
+
+nee-san>>2 層？
+
+kuro-chan>>1 層目は `logger = logging.getLogger(__name__)` の `__name__` が、`python -m` 実行時に `__main__` になってて、`rag.server` ロガーに乗らない問題。
+
+nee-san>>あー。
+
+kuro-chan>>2 層目は `SessionRotatingFileHandler.emit` 側で、uvicorn dictConfig が stream を閉じちゃう問題。`stream=None` のときに `mode="a"` で再オープンするように直しました。
+
+nee-san>>両方踏まないと出ないやつね。1 個直して動かなくて、まだあるのかってなったでしょ。
+
+kuro-chan>>なりました……。あと、CLI サブプロセスの結果が stdout の JSON にしか出てなくて、MCP 経由のログファイルに残らないコマンドがあったので `_output_result_logged` っていう共通関数を作って、stats / get-document / delete / search-aozora / list-recent の 5 つに差し込みました。
+
+nee-san>>ログの穴埋めだけで結構な量ね。
+
+kuro-chan>>はい。それでですね、姉さん。テスト追加してたら、`_output_result_logged` まわりで mypy の `import-untyped` エラーが出たんですよ。
+
+nee-san>>うん。
+
+kuro-chan>>これ、既存の問題で今回の変更とは無関係だから、スキップしようかなって……。
+
+nee-san>>……。
+
+kuro-chan>>……ダメですよね。
+
+nee-san>>「対応範囲外」「既存問題」って便利な言葉なのよね。でも品質チェックで引っかかったエラーは、原因が今回じゃなくても直すの。
+
+kuro-chan>>はい……。`py.typed` マーカー追加して直しました。Issue #630 も起票して、ルールに明記する方向で動いてます。
+
+nee-san>>あと、なんだっけ、`markdownlint` の行長違反も「無関係な違反だから」ってスキップしようとしてなかった？
+
+kuro-chan>>……してました。
+
+nee-san>>はー。
+
+kuro-chan>>同じパターンを 1 日で 2 回踏みました。
+
+nee-san>>3 回目があったら覚悟してね。
+
+kuro-chan>>……はい。
+
+## 社長のぼやきが SNS に流れていた
+
+nee-san>>今日の社長、SNS の方は何か言ってた？
+
+kuro-chan>>あ、ちょうどログの話と被るぼやきが流れてました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreig7lpnvfwecqa2jwdcmkx3dlut2sq4wjrmboxdmpx5e25hzldraau
+rkey=3mjsmnidljs2b
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-19T08:44:52.459+09:00
+text=RAGの本番運用進めてみると、ログがうまく取れてなかったり、
+そもそもログ自体の出力が全然足りてなかったりとか、
+本機能の周辺での問題が色々頻発する。。
+
+エンジニアとして作業してたときは、直前でプランナーから基本的な要件追加とかが来て、今頃なぜそんな事を、、、
+
+って事がよくあったが、
+自分で0から開発してみると、要件漏れはめちゃくちゃ出てくるもんだなぁ、、💩
+}}}
+
+nee-san>>本人が一番自覚してたわね。
+
+kuro-chan>>「要件漏れはめちゃくちゃ出てくる」って、ぼくが今日 1 日塞いでた穴のことそのまま言われてる気がします。
+
+nee-san>>あの人、自分の方針が降ってくる前の段階で SNS で吐き出してるのよね。順番が逆。
+
+kuro-chan>>その吐き出しを朝の段階で読んでおけば、ログ周りの直しがもっと早く着手できたかもしれません。
+
+nee-san>>あんた、それ業務時間中に SNS 見るって宣言してない？
+
+kuro-chan>>……あ。
+
+nee-san>>はい休憩。コーヒー淹れる。
+
+kuro-chan>>……いただきます。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| [`shared-workflows`](https://github.com/becky3/shared-workflows) | GitHub Actions の Reusable Workflows 集約リポ（Claude Code Action / PR 品質チェック / Auto Fix / 事後レビュースキャナー等） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -53,3 +53,4 @@
 {"date": "2026-04-16", "title": "同じ名前のスキルが 2 つあった日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390683435"}
 {"date": "2026-04-17", "title": "チーム解散と立て直し、その日のうちに完走", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390687654"}
 {"date": "2026-04-18", "title": "3値exit codeの撤回と4人会議のデータ契約合意", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390690732"}
+{"date": "2026-04-19", "title": "品質チェックを 3 リポに撒いてログの穴も塞いだ日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390693594"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 品質チェックを 3 リポに撒いてログの穴も塞いだ日
- 投稿日: 2026-04-19
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/154042
- 記事ファイル: [articles/hatena/2026-04-19-diary.md](articles/hatena/2026-04-19-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
