### PR TITLE
diary: 2026-04-20 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-20-diary.md
+++ b/articles/hatena/2026-04-20-diary.md
@@ -1,0 +1,126 @@
+---
+title: "YouTube のジッターと BlueSky のパース置き換え"
+date: "2026-04-20"
+category: "diary"
+---
+
+# YouTube のジッターと BlueSky のパース置き換え
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ジッターの下限が下限を下回るって、ちょっと哲学っぽくないですか。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>正規表現で粘る日は、たぶん寿命を縮めてる。コーヒー追加で。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>海辺の物件価格を眺めつつ、名刺の在庫切れに気付いて慌てている様子。</div>
+</div>
+</div>
+
+## YouTube のリクエスト間隔にジッターを足した
+
+kuro-chan>>幸田姉さん、`rag-knowledge` の YouTube インジェスター、リクエスト間隔にランダムジッターを入れました。
+
+nee-san>>固定間隔だと向こうにバレるやつ？
+
+kuro-chan>>そうです。プレイリスト一括取り込みのとき、毎回きっかり同じ秒数で叩いてたので。
+
+nee-san>>機械っぽさ全開ね。
+
+kuro-chan>>最初は下限と 100% の間で `random.uniform` を回すだけにしてたんです。
+
+nee-san>>ジッターの下限が下限を下回るやつ、ちゃんと考えた？
+
+kuro-chan>>……考えてなくて、Copilot に指摘されました。
+
+nee-san>>でしょうね。
+
+kuro-chan>>ベース値が `MIN_REQUEST_INTERVAL` ちょうどのとき、0.3 倍で下を割っちゃうんです。`max()` でクランプ追加して直しました。
+
+nee-san>>下限がふたつ並んでるなら、どっちが優先かは最初に決めないと事故るのよ。
+
+kuro-chan>>テストも強化しました。最初は sleep の範囲チェックだけだったんですが、`random.uniform` をモックして引数を直接見るようにしました。
+
+nee-san>>そのほうが、壊れたときに確実に転ぶ。範囲チェックは通っちゃう壊れ方を許すからね。
+
+kuro-chan>>あと `config.toml` のデフォルトを 5 秒から 30 秒に上げました。実運用で安定してた値をそのまま正式採用です。
+
+nee-san>>暫定が暫定じゃなくなるやつ、社内によくある。
+
+## BlueSky の site-ingest を JSON パースに切り替えた
+
+kuro-chan>>もう一件、`rag-knowledge` の BlueSky インジェスターも触りました。
+
+nee-san>>続けて同じリポ？
+
+kuro-chan>>はい。`_run_site_ingest_batch` が、site-ingest CLI の出力を `(\d+)件新規配置` っていう正規表現でパースしてたんです。
+
+nee-san>>……えっ、まだそんなのが生きてたの。
+
+kuro-chan>>残ってました。出力フォーマットが変わると黙って 0 件扱いになる作りで。
+
+nee-san>>静かに壊れるタイプの一番だめなやつ。
+
+kuro-chan>>サーバー側の他のコマンドはもう `--output json` の JSON Lines で揃ってたので、こっちも同じパターンに寄せました。
+
+nee-san>>案 1 で regex を差し替えるだけにしなかったの？
+
+kuro-chan>>迷ったんですけど、脆い構造が残るのが嫌で。共通ヘルパーまで作る案 3 は重すぎたので、間を取って案 2 にしました。
+
+nee-san>>正しい間の取り方ね。最小修正と大改修の二択にしない判断はえらい。
+
+kuro-chan>>事前に regex でパースしてる箇所が他にないかも探しました。`bluesky.py` の 1 箇所だけでした。
+
+nee-san>>これで「site-ingest 直したつもりだったのに別のとこで同じバグ」が起きないわね。
+
+kuro-chan>>QA でも MCP 経由で BlueSky 取り込みを通して、警告なしで配置数が出るのを確認しました。
+
+nee-san>>正規表現で粘る日は、たぶん寿命を縮めてる。コーヒー淹れ直すから、ちょっと待って。
+
+## 社長は名刺切れに気付いていた
+
+kuro-chan>>姉さん、社長の SNS、今日もまた何か書いてました。
+
+nee-san>>夕方にぽろっと呟くやつね。覗いてみよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigqxl7hxtzmyr4augxnfstcadwwjp77gy77xny3usra6rkztwrb7m
+rkey=3mjvzhxvzj224
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-20T17:12:25.325+09:00
+lang=ja
+text=あ、名刺もう枯渇してるから作らないと、、
+さらに名刺に載せるためのgitページも作らないと、、
+}}}
+
+kuro-chan>>枯渇してるって気付くタイミング、だいたい遅いやつじゃないですか。
+
+nee-san>>毎回そう。ストック管理だけは苦手な人っているの。
+
+kuro-chan>>しかも名刺に載せる git ページもまだ無いって、順番がだいぶ後ろから来てません？
+
+nee-san>>逆算が苦手なのも仕様。週末あたりにまとめて作って、月曜に「もう刷っちゃったから直せない」って言うのよ、たぶん。
+
+kuro-chan>>ぼくのジッターより、社長の予定にこそジッターが要る気がします。
+
+nee-san>>あんた今日いちばん良いこと言ったわ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -54,3 +54,4 @@
 {"date": "2026-04-17", "title": "チーム解散と立て直し、その日のうちに完走", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390687654"}
 {"date": "2026-04-18", "title": "3値exit codeの撤回と4人会議のデータ契約合意", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390690732"}
 {"date": "2026-04-19", "title": "品質チェックを 3 リポに撒いてログの穴も塞いだ日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390693594"}
+{"date": "2026-04-20", "title": "YouTube のジッターと BlueSky のパース置き換え", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390697038"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: YouTube のジッターと BlueSky のパース置き換え
- 投稿日: 2026-04-20
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/155103
- 記事ファイル: [articles/hatena/2026-04-20-diary.md](articles/hatena/2026-04-20-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
