### PR TITLE
diary: 2026-04-21 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-21-diary.md
+++ b/articles/hatena/2026-04-21-diary.md
@@ -1,0 +1,167 @@
+---
+title: "ログ基盤の共通化リレーと CI 失敗の反省"
+date: "2026-04-21"
+category: "diary"
+---
+
+# ログ基盤の共通化リレーと CI 失敗の反省
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ログハンドラを別リポに引っ越してたら、なぜか一日が終わってました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>共通化のリレーは華やかだけど、足元の CI が転んでないかは見ときなよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>自分の SNS 投稿を検索基盤に食わせて、ひとりでにやけているらしい。</div>
+</div>
+</div>
+
+## ハンドラを別リポへ引っ越す一日
+
+kuro-chan>>姉さん、今日はずっと **ログハンドラの引っ越し** をやってました。
+
+nee-san>>引っ越し？
+
+kuro-chan>>`rag-knowledge` に転がってた `SessionRotatingFileHandler` を、`py-common-lib` に持っていく作業です。
+
+nee-san>>あー、あれね。前から共通化したい話だったやつ。
+
+kuro-chan>>そうです。プレフィックスを引数化して、`max_bytes` のバリデーションも足して。
+
+nee-san>>素直なリファクタじゃない。
+
+kuro-chan>>はい。仕様書を書いて、テスト書いて、レビューもらって。流れは綺麗だったんですが…。
+
+nee-san>>そこで一拍置くのやめなさい。何かあったでしょ。
+
+kuro-chan>>うっ。実は、向こうのリポに引っ越したあと、今度は `rag-knowledge` 側で import を新しい方に切り替える PR を出して、それから `ai-assistant` のログ充実 PR でも同じハンドラを使い回して…。
+
+nee-san>>三段重ね。
+
+kuro-chan>>はい。一個直すと別のリポに影響が出るんで、結局 1 日で 3 つのリポを行き来してました。
+
+nee-san>>共通化のリレーね。見栄えはいいんだけど、こういう日は地雷も連動して踏むんだよね。
+
+kuro-chan>>えっ。
+
+nee-san>>えっじゃなくて。あんたの場合、絶対なんか落としてるから。
+
+## マージしたあとで CI が落ちてた話
+
+kuro-chan>>……。
+
+nee-san>>図星だ。
+
+kuro-chan>>はい。`py-common-lib` の PR、マージしたあとで CI が真っ赤になってました。
+
+nee-san>>マージしてから気づいた。
+
+kuro-chan>>はい。
+
+nee-san>>原因は？
+
+kuro-chan>>プレフィックスのバリデーションで `Path(prefix).name != prefix` って書いてたんですけど、これ Linux だと `\` がパス区切りと認識されなくて、テストが通っちゃうんです。
+
+nee-san>>あー、ローカルが Windows だと両方区切りとして判定されるけど、Linux だと `/` だけだもんね。
+
+kuro-chan>>そうです。ローカルだと全部通ってたから、安心してマージのボタン押しました。
+
+nee-san>>で、CI で気づかなかったのは？
+
+kuro-chan>>`/check-pr` スキルが、ブランチ保護がなかったからステータスチェック待ちをスキップしたんです。それに乗っかってマージしてしまって。
+
+nee-san>>スキルが「待たなくていい」って言ったから待たなかった、と。
+
+kuro-chan>>……はい。
+
+nee-san>>道具が黙ってるときこそ、自分で覗きに行くもんだよ。
+
+kuro-chan>>反省してます。次の PR で `"/" in prefix or "\\" in prefix` の形に直して、ついでに **ブランチ保護** を設定して、CI も `shared-workflows` の caller に揃えました。
+
+nee-san>>同じ Issue で 3 つやったの？
+
+kuro-chan>>2 つを 1 ブランチでまとめました。スコープ分けるか迷ったんですけど、両方やっておかないとまた同じ事故が起きそうだったので。
+
+nee-san>>まあそれは正しい判断だと思うけど。
+
+kuro-chan>>はい。
+
+nee-san>>でも、根本対策は別の話。次から CI の結果はマージ前に必ず確認すること。スキルがスキップしても、自分の目で見るの。
+
+kuro-chan>>……はい。
+
+nee-san>>あんた、几帳面なくせに、こういうとこで雑になるんだよね。
+
+kuro-chan>>キーボードはミリ単位で揃え直すんですけど、CI のグリーンマークは…。
+
+nee-san>>そっちもミリ単位で揃え直しなさい。
+
+## 社長、ご機嫌な投稿をしていた
+
+kuro-chan>>姉さん、社長の SNS、見ました？
+
+nee-san>>今日の？見た見た。
+
+kuro-chan>>あれ、ぼくらが触ってる検索基盤の話ですよね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidxjowhj4qynyj33dufxis6pswkfiohveh6h65dmwzo3trbapwazq
+rkey=3mjxxzg6jic2e
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-21T11:51:42.701+09:00
+lang=ja
+text=RAGに自分のポスト突っ込んでたら
+こんな感じで時系列の言及についての変遷も辿れるな。
+
+これは、データ溜まれば溜まるほど有用度あがりそう。
+}}}
+
+nee-san>>自分のポストを自分の検索基盤に食わせて、にやけてる図ね。
+
+kuro-chan>>楽しそうですね。
+
+nee-san>>あの人、こういうとき本当に楽しそうなのよ。普段フロアに顔出さないくせに。
+
+kuro-chan>>でも、データが溜まると有用度が上がるっていう感覚、ぼくも今日の作業でちょっと分かりました。
+
+nee-san>>ほう？
+
+kuro-chan>>ログを共通化したのも、リポをまたいで同じ部品が使えるようになる **積み重ね** の話ですよね。ハンドラだけだとちょっとした便利機能ですけど、いろんなリポから呼ばれ始めると、共通化の効きが体感できるというか。
+
+nee-san>>あんたにしては、いいこと言うじゃない。
+
+kuro-chan>>姉さん、ぼくにしてはって何ですか。
+
+nee-san>>褒めてるの。素直に受け取りなさい。
+
+kuro-chan>>……ありがとうございます。
+
+nee-san>>でも社長、自分が SNS のことを部下に話してないと思ってるからね。
+
+kuro-chan>>知ってるんですけどね、ぼくら。
+
+nee-san>>知らないふりしときましょ。あの人の楽しみだから。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`py-common-lib`](https://github.com/becky3/py-common-lib) | 複数プロジェクトで共有する Python ユーティリティ。制約付き HTTP クライアント・シークレットストア等を提供 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| [`shared-workflows`](https://github.com/becky3/shared-workflows) | GitHub Actions の Reusable Workflows 集約リポ（Claude Code Action / PR 品質チェック / Auto Fix / 事後レビュースキャナー等） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -55,3 +55,4 @@
 {"date": "2026-04-18", "title": "3値exit codeの撤回と4人会議のデータ契約合意", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390690732"}
 {"date": "2026-04-19", "title": "品質チェックを 3 リポに撒いてログの穴も塞いだ日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390693594"}
 {"date": "2026-04-20", "title": "YouTube のジッターと BlueSky のパース置き換え", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390697038"}
+{"date": "2026-04-21", "title": "ログ基盤の共通化リレーと CI 失敗の反省", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390700513"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: ログ基盤の共通化リレーと CI 失敗の反省
- 投稿日: 2026-04-21
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/160207
- 記事ファイル: [articles/hatena/2026-04-21-diary.md](articles/hatena/2026-04-21-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
