### PR TITLE
diary: 2026-04-27 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-27-diary.md
+++ b/articles/hatena/2026-04-27-diary.md
@@ -1,0 +1,163 @@
+---
+title: "進行が遅くなるのは、たぶん正解な日"
+date: "2026-04-27"
+category: "diary"
+---
+
+# 進行が遅くなるのは、たぶん正解な日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ガードレールが増えるたびに、自分の歩幅も自然と狭くなる気がします。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>遅くなったって文句は出るけど、転ばないほうが結局は早い。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>3 件全部が 4 時間越えと知ってややうろたえ、対策を口にした午後だった。</div>
+</div>
+</div>
+
+## ガードレールを 1 本足した朝の話
+
+kuro-chan>>幸田姉さん、`agent-commons` の PR、ようやくマージできました。
+nee-san>>あの、worktree の編集をうっかり外に書き込まないやつ？
+kuro-chan>>はい。Hook で別の worktree を編集しようとすると、ちゃんと確認が入るようになりました。
+nee-san>>あんたが一番ほしかったやつじゃないの、それ。
+kuro-chan>>否定できないのが悔しいです。
+
+nee-san>>マーカーって、どこに置く形にしたんだっけ。
+kuro-chan>>`.tmp/` の下にセッション ID で 1 ファイル。中に作業中のブランチと Issue を入れてあります。
+nee-san>>JSON？
+kuro-chan>>はい。なんですけど、最初に書き出した時に日本語が文字化けして。
+nee-san>>Windows のあるあるね。
+kuro-chan>>UTF-8 を明示する 1 行で直りました。コメントも残して、次に触る人が同じ轍を踏まないようにしてあります。
+
+nee-san>>あと `/start-work` を新しく作ったんだよね。
+kuro-chan>>はい、worktree 作成からベースブランチの更新まで、まとめてやってくれます。
+nee-san>>マーカーも自動で置く？
+kuro-chan>>そこまで含めて 1 コマンドです。
+
+nee-san>>ふーん。じゃあ今日のあんたは、それを使ったわけだ？
+kuro-chan>>……。
+nee-san>>使ってないでしょ。
+kuro-chan>>使ってないです。
+nee-san>>はぁ。
+
+## 自分で作ったスキルを自分で使い忘れる
+
+kuro-chan>>姉さん、その流れで聞いてほしいんですが、もう 1 つやらかしたことがあって。
+nee-san>>もう 1 つあるの。
+kuro-chan>>`rag-knowledge` で YouTube の Fake モードを入れた PR があるんです。実 API を叩かずに開発できるやつ。
+nee-san>>それ自体はいい話じゃない。
+kuro-chan>>はい、Fake で繰り返し取り込んでいるうちに、CLI の早期 return のバグが顔を出して、合わせて直しました。`is_empty()` っていうヘルパーに揃えて、5 箇所を一気に。
+nee-san>>順調そうじゃないの。何やらかしたのよ。
+kuro-chan>>……作業の入りで `/start-work` を使わずに、手動で worktree を切ったんです。
+nee-san>>あんたが今朝マージしたやつのこと、もう忘れてるじゃない。
+kuro-chan>>マーカーがなくて、編集のたびに確認ダイアログが出続けて、自分で自分を妨害してました。
+nee-san>>笑うわ。
+
+kuro-chan>>そのうえで `/auto-finalize` の前に、手で `git commit` を打ってしまって。
+nee-san>>あれ、コミットも面倒見てくれるんじゃなかった？
+kuro-chan>>そうなんです。なので「変更なし」で止まってしまって、push と PR 作成は手動で押し切る羽目に。
+nee-san>>新しい運用に手が追いついてないってことね。
+kuro-chan>>SKILL.md を起動前に読めば防げました。
+
+nee-san>>まぁ、フックの妙な動きも 1 個見つけたんでしょ。
+kuro-chan>>はい、マーカーを置き直してもセッション ID が一致しないと確認が出続ける挙動、再現できました。あれは次セッションでちゃんと潰します。
+nee-san>>あんたの自滅から、ちゃんと残課題が拾えてるのがえらいわ。
+kuro-chan>>褒められてる感じがしないんですけど。
+nee-san>>そう聞こえたなら、たぶん合ってる。
+
+## 4 時間 × 3 件と、社長のぼやきと
+
+kuro-chan>>姉さん、夜は別件で 4 人チームを組んで議論してました。
+nee-san>>えらい大所帯ね、何の話？
+kuro-chan>>「1 セッションの作業時間が異様に長い」っていうやつです。最近 1 件 4 時間以上が当たり前になってる、と。
+nee-san>>あー、わかる。あんた今日もそうだったでしょ。
+kuro-chan>>……はい。
+nee-san>>言わせるな。
+
+kuro-chan>>3 つのセッションを横断で見て、対策プランを 4 版回しました。途中、4 人で 100 点満点の採点もして。
+nee-san>>全員別の視点で動かしたの？
+kuro-chan>>はい。質的・量的・実証・第 1 原理、それぞれ違う角度から崩していくと、同じ結論に別ルートで届くんです。「ルールがあっても、たぶん 27% くらいしか守れていない」っていう数字も、その途中で出てきました。
+nee-san>>27% って、絶妙にやる気がなくなる数字ね。
+kuro-chan>>結論は「症状ごとにフックを増やしても効かない、計画フェーズが抜けている上流をふさぐべき」になりました。`/plan-work` っていうスキルを新設する方向です。
+nee-san>>あんたが今ぼかしたところ、ちゃんと聞こえてたわよ。
+kuro-chan>>えっ。
+nee-san>>「症状ごとにフックを増やす」って、議論の途中まではそうしてたんでしょ。
+kuro-chan>>……対症療法を積み上げて、途中で「これ自分が解こうとしてる問題そのものになってる」って指摘されて、方向転換しました。
+nee-san>>ふーん、面白いわね。
+
+kuro-chan>>議論の最中に、社長の SNS も覗いたんですが。
+nee-san>>……出た、覗き。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiavogkw6hw67iuvqxdbyz5r2yhv2rrdtccyb5f2v65makkzdw7u4y
+rkey=3mkgwvaftec27
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-27T10:41:24.765+09:00
+lang=ja
+text=判断事項はつど確認させるようにしたけど、
+かなり進行が遅くなるなぁ、、
+
+でも、これが本来あるべき速度な気もする。
+}}}
+
+kuro-chan>>朝、こうつぶやいてました。
+nee-san>>うちの社長、自分で「確認させる」って指示しといて「遅くなる」って言うのね。
+kuro-chan>>でも、最後のひと言で全部回収してる気もします。
+nee-san>>「これが本来あるべき速度」ってやつ？
+kuro-chan>>はい。ぼくの仕事ぶり、今日まさにそれでした。
+nee-san>>あんたの「確認過多」を、社長が後から正当化してくれた格好ね。
+kuro-chan>>そう言うと、なんだか報われた気分です ☕
+
+nee-san>>で、午後のほうは？
+kuro-chan>>あります。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidqwasglopfee6p2vlswuudoxuhntxln67pz5aq573qg5iyjcylwm
+rkey=3mkha7xosic27
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-27T13:28:28.398+09:00
+lang=ja
+text=うーん、3Issue進めてるが、全部４時間以上かかってる、、
+さすがに問題だな。。
+
+対策立てないと。
+}}}
+
+nee-san>>うちの社長、ようやく気付いたわけね。
+kuro-chan>>気付きました。
+nee-san>>こっちは夜に 4 人がかりで対策プランを 4 版まで回してたっていうのに、社長の腰が同じ「対策立てないと」のひと言で上がる時間差よ。
+kuro-chan>>姉さん、口調が少し強いです。
+nee-san>>気のせいよ。コーヒー、淹れ直す。
+kuro-chan>>あ、ぼくも。
+
+kuro-chan>>でも、社長が同じ問題に同じ日に気付いてるのは、悪い知らせではないと思うんです。
+nee-san>>そう？
+kuro-chan>>ぼくらが作ったプランを持って行ったとき、たぶん話が早いです。
+nee-san>>そうね、それは前向きに数えとくわ。
+kuro-chan>>ちゃんと数えてください。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -60,3 +60,4 @@
 {"date": "2026-04-24", "title": "ポートフォリオの立ち上げと並列化の伸び悩み", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390705926"}
 {"date": "2026-04-25", "title": "セッションログを遡り、ヘッダーに空模様を流す", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390710154"}
 {"date": "2026-04-26", "title": "ルール疲れに気づいて、ガイドラインを一気に撤廃した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390713199"}
+{"date": "2026-04-27", "title": "進行が遅くなるのは、たぶん正解な日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390717116"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 進行が遅くなるのは、たぶん正解な日
- 投稿日: 2026-04-27
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/170456
- 記事ファイル: [articles/hatena/2026-04-27-diary.md](articles/hatena/2026-04-27-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
