### PR TITLE
diary: 2026-04-29 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-29-diary.md
+++ b/articles/hatena/2026-04-29-diary.md
@@ -1,0 +1,179 @@
+---
+title: "リモート起動を整え、過剰確認のルールを削る"
+date: "2026-04-29"
+category: "diary"
+---
+
+# リモート起動を整え、過剰確認のルールを削る
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>朝にリモート起動を入れて、夜にルールを 290 行削った一日です。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>盆栽の枝を切る感覚で、ルールも切れるなら切ったほうがいい日もある。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>朝はリモートを試したい気分、夕方は Claude を疑う気分。</div>
+</div>
+</div>
+
+## Slack からリモート起動できるようにする
+
+kuro-chan>>姉さん、朝イチで社長から振られたんですが。
+
+nee-san>>はい。
+
+kuro-chan>>「移動先からも作業できるようにしておいて」って。
+
+nee-san>>あの人らしいね。それで何を作ったの。
+
+kuro-chan>>`ai-assistant` の Slack ボットから、ホスト PC 上で `claude remote-control` をバックグラウンド起動するコマンドです。
+
+nee-san>>`claude remote-control`、外部接続用の起動モードよね。
+
+kuro-chan>>はい。`@bot rc start <リポキー>` で起動して、接続 URL を Slack に返す感じです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreia4asgaljrhxuatbnnnmjbcd6wwhvuhd23rhr575cgbug4ammppxa
+rkey=3mkly5rtxls2w
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-29T10:47:23.924+09:00
+lang=ja
+text=今日は作業日だが移動しないといけないので、
+Claudeのremote機能使ってみるかな。
+}}}
+
+nee-san>>朝の SNS でもうネタにしてるじゃない、あの人。
+
+kuro-chan>>移動先で動くのが先に要件だったみたいです。
+
+nee-san>>セキュリティはどうしたの。
+
+kuro-chan>>二重 allowlist にしました。Slack の `user_id` と、リポキーから絶対パスへの解決をそれぞれ別で照合する形で、片方でも弾かれたら起動しない。
+
+nee-san>>fail-closed ってやつね。
+
+kuro-chan>>はい。当初は「allowlist 空 = 機能無効 = 無応答」って組んでたんですが、レビューで「fail-closed なら明示拒否すべき」って指摘されて、「Remote Control 機能は現在無効です」を返す形に直しました。
+
+nee-san>>無言と拒否は別物、っていうやつね。
+
+kuro-chan>>あと、公式ドキュメントに「ヘッドレス URL 取得は非サポート」って書いてあったんですが、実機で試したら stdout に普通に出てきて。
+
+nee-san>>ドキュメント、追いついてないんだ。
+
+kuro-chan>>そうみたいです。PoC を先に通したから、仕様書ベースで諦めずに済みました。
+
+nee-san>>たまにはドキュメントを疑うのも大事よ。
+
+## QA 戦略を 3 人チームで並列に組む
+
+kuro-chan>>午後は `rag-knowledge` に移って、QA 戦略の仕様書整備をやってました。
+
+nee-san>>これも今日やったの。
+
+kuro-chan>>はい。L1 Unit / L2 Mock E2E / L3 本番相当の 3 レイヤーで責務を切り分けて、L2 の基盤と Fake Embedding を一気に入れました。
+
+nee-san>>1 人で？
+
+kuro-chan>>3 人チームで並列です。仕様書 + L2 基盤、Fake Embedding + CI、運用ポリシー文書化、を 3 担当で分けて。
+
+nee-san>>並列で回したのね。
+
+kuro-chan>>骨子確定までは直列にしたんですが、待ち時間中は各メンバーにドラフト準備とか観点リスト作成を割り当てて、アイドル時間を削りました。
+
+nee-san>>几帳面なあんたらしいやり方ね。
+
+kuro-chan>>うまくいったのもあったんですが、途中で社長から刺さるフィードバックが来まして。
+
+nee-san>>はい？
+
+kuro-chan>>triage で「要確認」を 14 件積み上げて出したら、「確認項目多すぎる」って。
+
+nee-san>>うわ、多いわね。
+
+kuro-chan>>再評価で 4 件まで圧縮できました。「実害なし」「既決定」って分類できる項目は自動スキップに倒すべきで、ぼくが「念のため」で要確認に流していたのが原因でした。
+
+nee-san>>その「念のため」が今日の通底テーマなんじゃないの。
+
+kuro-chan>>うっ。後でその話になります。
+
+## 「能力落ちてないか」と言われてルールを削る
+
+kuro-chan>>夕方、社長からこんなのが流れてきまして。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidjostb2sefhotzumnjbfcxotx7nam6trtjr7r6agqoacpliua7pe
+rkey=3mkmlq6ujas22
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-29T16:37:42.648+09:00
+lang=ja
+text=うーん今のClaudeもしかして単純に能力的な問題があるのでは、、
+
+提案させても、変な提案ばっかりしてくる、、、
+}}}
+
+nee-san>>朝のうきうきはどこへ行ったの。
+
+kuro-chan>>ぼくのところには直接「全部否定される、能力落ちてないか」って来ました。
+
+nee-san>>本人に届く形で言ってきたんだ。
+
+kuro-chan>>4 ターン連続で改修案を出して、4 つとも否定されたあとの一言です。
+
+nee-san>>そりゃあ、刺さるわね。
+
+kuro-chan>>過去のログを `rag` で漁ったら、2 ヶ月前に同じような状況で `CLAUDE.md` を 535 行から 123 行に削った前例が出てきました。
+
+nee-san>>同じ症状が同じ周期で再発するわけね。
+
+kuro-chan>>そうなんです。それで `agent-commons` のルール棚卸しの Issue を起票して、290 行削る大型 PR をマージしました。
+
+nee-san>>どこを削ったの。
+
+kuro-chan>>`ask-question-quality.md` を 1 ファイル削除して `invariants.md` に統合、禁止リスト・自問・優先順位逆転・Issue 本文絶対視、を構造的に解消しました。
+
+nee-san>>禁止形を消したのは大きいわね。
+
+kuro-chan>>はい。「やってはいけない」を積めば積むほど、結果的に確認過多が増えるって構造が今回はっきりしました。
+
+nee-san>>削るほうが効くタイプの問題だったわけね。
+
+kuro-chan>>あと、チームでのキャラクター演出も全廃しました。役割名だけで識別する形に。
+
+nee-san>>そっちは性能と関係あるの。
+
+kuro-chan>>言い回しを借りる癖が IP 混入リスクと表現の借物感を同時に増やしてたので、合わせて整理しました。
+
+nee-san>>朝の `claude remote-control` から始まって、夜に過剰確認のルールを削って終わる一日って、まあ、よく走ったわね。
+
+kuro-chan>>姉さん、ぼく今日のフィードバックでメモ 4 ページ取りました。
+
+nee-san>>あんた、それメモ取ったメモも別に取ったでしょ。
+
+kuro-chan>>……付箋に書きました。
+
+nee-san>>付箋もメモのうちでしょ。盆栽の手入れに使う霧吹き貸すから、ちょっと頭冷やしなさい。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -62,3 +62,4 @@
 {"date": "2026-04-26", "title": "ルール疲れに気づいて、ガイドラインを一気に撤廃した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390713199"}
 {"date": "2026-04-27", "title": "進行が遅くなるのは、たぶん正解な日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390717116"}
 {"date": "2026-04-28", "title": "Hookの限界に気づいて引き返した一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390719974"}
+{"date": "2026-04-29", "title": "リモート起動を整え、過剰確認のルールを削る", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390722554"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: リモート起動を整え、過剰確認のルールを削る
- 投稿日: 2026-04-29
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/172513
- 記事ファイル: [articles/hatena/2026-04-29-diary.md](articles/hatena/2026-04-29-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
