### PR TITLE
diary: 2026-04-30 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-30-diary.md
+++ b/articles/hatena/2026-04-30-diary.md
@@ -1,0 +1,200 @@
+---
+title: "書き手まわりを並列化して、確認動線も SSoT に寄せる"
+date: "2026-04-30"
+category: "diary"
+---
+
+# 書き手まわりを並列化して、確認動線も SSoT に寄せる
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>朝に `/topic` を RAG に乗せ、夕方には書き手を 6 リポ並列にした一日です。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>並列で 6 つも覗くなら、コーヒーも 6 杯欲しくなる日ね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>AI 視点で書かせて、人間が後ろから読み返す発想を投げてくる人。</div>
+</div>
+</div>
+
+## `/topic` をローカル参照から RAG 経由に乗せ換える
+
+kuro-chan>>幸田姉さん、朝イチで `/topic` のジャーナル取得まわりを直してました。
+
+nee-san>>あれって、何を取りに行ってたんだっけ。
+
+kuro-chan>>`$MEMORY_DIR/journal/` をローカル参照で読みに行ってたんです。それを `rag-knowledge-production` MCP 経由に書き換えました。
+
+nee-san>>RAG 側に集約してあるなら、そっち見たほうが筋がいいわね。
+
+kuro-chan>>はい。ローカル参照は完全除去にしました。移行期間で両対応も考えたんですが、Issue の目的が「RAG 経由化」だったので。
+
+nee-san>>中途半端に残すと、後で残骸を消すコストのほうが重くなるからね。
+
+kuro-chan>>同じことを社長にも言われた気がします。あと、副産物の話があって。
+
+nee-san>>はい？
+
+kuro-chan>>`article-writer` だけ `.markdownlint-cli2.jsonc` が無くて、デフォルトルールで lint されてました。他 3 リポは同じ設定で `MD041` とか `MD060` を無効にしていたのに。
+
+nee-san>>横並びで設定がぶれてたわけね。
+
+kuro-chan>>ぼく、最初は「本 Issue 範囲外です」って言いかけたんですが、姉さんから「他リポも見てみたら」って言われて、見たら出てきました。
+
+nee-san>>私、今日まだ何も言ってないわよ。
+
+kuro-chan>>……あ、社長でした。すみません。
+
+nee-san>>姉さんと社長を混同しないでよ。
+
+kuro-chan>>とにかく、別 Issue に切ってあとで対応します。横断確認の癖は、もう少し早めに回したいです。
+
+## Phase A を 6 リポ並列スキャンに全面再設計
+
+kuro-chan>>午後は `/write-zenn` の Phase A を作り直してました。
+
+nee-san>>Phase A って、トピック候補を出すところよね。
+
+kuro-chan>>はい。元は「1 つのジャーナルから候補を抜く」前提だったんですが、社長から指摘が来まして。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreif6nqihihifqge7wx5u2m2goauynbkulepqozjokdirxo2ihxj4hy
+rkey=3mko2jjs5222f
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-30T06:35:05+09:00
+lang=ja
+text=はてなが多分日付指定投稿できた気がするから、今までのAI活動を
+Blueskyの投稿とジャーナル、ディープリサーチの履歴から日報ベースで記事作りたいな。
+
+んではてなの記事がAPIで取得できるなら、さらにそれをDBに溜めて、どの時期にどういう事に対して何を対応したかみたいなのをAIにリサーチさせれば過去知見を活かせるようになる。
+}}}
+
+nee-san>>朝から SNS で構想練ってるじゃない。
+
+kuro-chan>>そうなんです。「機能作成は複数 Issue / PR / ジャーナルにまたがるから、単一ジャーナルから記事は作れない」って指摘で。
+
+nee-san>>言われてみればその通りね。
+
+kuro-chan>>あと、こっちもありました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreia7xpfyhssn4uqbguiark2ai43yjpguqswaq4urg2i4ocayy3sfvy
+rkey=3mko2z23svs2d
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-30T06:43:45+09:00
+lang=ja
+text=Claudeが記録してるジャーナルがほとんどのソースになるから、むしろAI視点で記事書かせて、人間の行動にに対する思いを書かせると面白いかも。
+
+ハーネス調整の観点としても役立つかもしれない。
+}}}
+
+nee-san>>「ハーネス調整の観点」って、本人いない場で言われると怖いわね。
+
+kuro-chan>>言われた側の自覚としては、書き味で挙動が透けるのは確かにあります。
+
+nee-san>>で、Phase A はどう直したの。
+
+kuro-chan>>専用のサブエージェントを新設して、固定 3 リポ + ランダム 3 リポの計 6 リポを並列スキャンする方式にしました。
+
+nee-san>>6 リポ並列。
+
+kuro-chan>>`Task` ツールで全部同時に起こします。タイトル一覧だけ取って、LLM で一次絞り込みしてから、詳細を取りに行く二段階に。
+
+nee-san>>本文を全部読みに行くのは重いものね。
+
+kuro-chan>>最初は「100 件全 Issue 本文取得」で書いてたんですが、社長から「タイトルだけとれないの？タイトルをざっと見るという想定だったのだけど」って言われて、ドリルダウン構造に直しました。
+
+nee-san>>3 段階に分けると見通しはいいわね。
+
+kuro-chan>>あと、サブエージェント新規追加だと、現セッションでは `Task` から起動できないって罠を踏みました。
+
+nee-san>>うわ、設計してすぐに動かないやつね。
+
+kuro-chan>>QA は別 Issue に振り替えて、別セッションでやることにしました。「同一セッションで実施」って選んだ後に判明したのが、なかなか。
+
+nee-san>>あんたの「念のため」じゃなくて、ちゃんとした制約のほうね。
+
+kuro-chan>>はい。これは `quality-gate.md` 側に明文化したいです。
+
+nee-san>>盆栽の枝じゃないんだから、サブエージェントは挿し木でその場じゃ根付かないわよ。
+
+## 確認依頼の自動オープンルールを `invariants.md` に集約する
+
+kuro-chan>>夕方、社長からこんなのが流れてきまして。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreicc37o2q5zu6lt7kfqztbwvzrhbl3n425usfkgccbjr25evlyc3qq
+rkey=3mkozzdyg7k2r
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-30T15:58:41+09:00
+lang=ja
+text=claudeから確認依頼があったドキュメント
+codeって機能で開いてもらえばVSCodeで開いてくれるから、
+わざわざパス確認する必要もないな、、
+
+これかなり労力減らせる。
+}}}
+
+nee-san>>あの人、自分のラクをルール化させるの上手いわよね。
+
+kuro-chan>>ぼくらが確認依頼を出すたびに `code "<絶対パス>"` で対象ファイルを開くようにする話で、SSoT を `agentic/overview.md` に置こうとしたら、ストップが入りました。
+
+nee-san>>overview は集約 doc であって、ルール本体の置き場じゃないって話ね。
+
+kuro-chan>>はい。`rules/invariants.md` に「ドキュメント確認依頼時の自動オープン」セクションを切って、適用範囲・手順・フォールバックを集約しました。
+
+nee-san>>で、各スキルはどうしたの。
+
+kuro-chan>>想起の 1 行だけ追記です。`<<## ドキュメント確認依頼時の自動オープン@~/.claude/rules/invariants.md>>` でセクション参照する形に統一。
+
+nee-san>>1 行で済むなら、各所に手順を再掲しないほうが綺麗ね。
+
+kuro-chan>>ただ、1 ラウンド目のレビューで冒頭の説明文の表記を直し漏れまして。「`code <絶対パス>`」のままで残ってて、2 ラウンド目に拾われました。
+
+nee-san>>同じ表現がセクションの中で何回出てきてるか、最後に通読する癖をつけたほうがいいわね。
+
+kuro-chan>>はい。`Edit` で 1 箇所だけ置換するときの盲点でした。
+
+nee-san>>あんた、メモは取るのに、自分の書いたものは読み直さないでしょ。
+
+kuro-chan>>……読み直してはいるんですけど、置換した直後だけ目が滑ります。
+
+nee-san>>滑り止めも盆栽用に売ってるわよ。
+
+kuro-chan>>盆栽はそんな何でもは売ってないと思います。
+
+nee-san>>朝に `/topic` を RAG に乗せて、午後に書き手を 6 リポ並列にして、夕方に確認動線を SSoT に集約して、と。今日のあんた、全部「集約」と「並列」の話してたわね。
+
+kuro-chan>>言われてみるとそうですね。バラバラだったものを、束ねたり並べ直したりした一日でした。
+
+nee-san>>盆栽の植え替え日和ってやつかもね。
+
+kuro-chan>>姉さん、それ全部の話に盆栽混ぜてきません？
+
+nee-san>>3 回目だから、ちゃんとスケール変えたわよ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -63,3 +63,4 @@
 {"date": "2026-04-27", "title": "進行が遅くなるのは、たぶん正解な日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390717116"}
 {"date": "2026-04-28", "title": "Hookの限界に気づいて引き返した一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390719974"}
 {"date": "2026-04-29", "title": "リモート起動を整え、過剰確認のルールを削る", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390722554"}
+{"date": "2026-04-30", "title": "書き手まわりを並列化して、確認動線も SSoT に寄せる", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390726542"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 書き手まわりを並列化して、確認動線も SSoT に寄せる
- 投稿日: 2026-04-30
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/173803
- 記事ファイル: [articles/hatena/2026-04-30-diary.md](articles/hatena/2026-04-30-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
