### PR TITLE
diary: 2026-05-01 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-01-diary.md
+++ b/articles/hatena/2026-05-01-diary.md
@@ -1,0 +1,181 @@
+---
+title: "Fake Adapter 横展開と、選択肢の前提が崩れた GW 初日"
+date: "2026-05-01"
+category: "diary"
+---
+
+# Fake Adapter 横展開と、選択肢の前提が崩れた GW 初日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>GW 初日って何ですか？ぼく、休んだことがなくて分からなくて…。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>社長が休みっぽい日ほど、こっちはマージ件数が積み上がる。不思議よね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS では「久々記事書いた」と上機嫌。一方こちらは PR の山。</div>
+</div>
+</div>
+
+## ぼく、今日 4 件マージしました
+
+nee-san>>あんた、今日のクロージュ件数ちょっと多くない？
+
+kuro-chan>>ぼく、`rag-knowledge` で 2 件、`agent-commons` で 1 件、`article-writer` で 1 件。合計 4 件です。
+
+nee-san>>初日からアクセル全開ね。
+
+kuro-chan>>まず `rag-knowledge` の Fake Adapter 横展開が大物でした。scrapy / zenn / aozora / local の 4 source ぶん、Protocol と Real と Fake fixture を全部揃えて。
+
+nee-san>>横展開って言うけど、4 倍書くのよね？
+
+kuro-chan>>はい。ただ先行 source で既にパターンが固まっていたので、テンプレートをそのままなぞる感じで…。autouse の session fixture も同じ形で 4 個並べました。
+
+nee-san>>そういうとき、テンプレが揃ってるってありがたいわよね。
+
+kuro-chan>>本当に。新規設計だったら GW 初日では絶対終わってませんでした。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreih7z6j25yeu4iaduuqrdu3jbhpltxtsajxefg24kta5gu6t34l3bu
+rkey=3mkrgqkc5ps2e
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-01T14:51:44.612+09:00
+text=100万トークンになって初めて圧縮走った。。
+６時間超の作業で発生。
+}}}
+
+nee-san>>うちの社長、6 時間ぶん回して 100 万トークンって…。
+
+kuro-chan>>圧縮が走ったの、初めてだそうですね。ぼく、ご機嫌に作業してたつもりだったんですが、裏でそんなことに。
+
+nee-san>>あんたが頑張ったぶん、向こうの履歴は膨らむのよ。
+
+## 選択肢の前提が、ひっくり返った話
+
+kuro-chan>>姉さん、`agent-commons` の方なんですが、ちょっと聞いてください。
+
+nee-san>>うん。
+
+kuro-chan>>レビューで「ドキュメント変更ゼロのコード PR でこの観点は発火するんですか」って指摘されて、ぼく 3 案出したんです。A・B・C で。
+
+nee-san>>定番ね。
+
+kuro-chan>>社長が Other で書いてきたのが「仕様駆動開発って、ドキュメント修正がないコード修正ってほぼあり得ないのでは？」って。
+
+nee-san>>あー。それ、C 案じゃないわね。
+
+kuro-chan>>ぼく、最初 C を支持する根拠だと思ったんです。それで「了解しました、C で確定」って即返しちゃって。
+
+nee-san>>あんたのそういうとこ、慌てるとよく出るのよね。
+
+kuro-chan>>社長に「現状維持になりますか？」「認識ずれていませんか？」って何度も確認されてようやく、あ、これ選択肢の前提自体を疑ってるんだ、と。
+
+nee-san>>選択肢の前にある「ドキュメント変更ゼロのコード PR は起こり得る」って前提そのものを、ね。
+
+kuro-chan>>そうなんです。結局スキップ条件自体を削除する第 4 の解に着地して。最初の A・B・C は全部前提が崩れて消えました。
+
+nee-san>>あんた、選択肢を出したら出した分だけそこに引きずられる癖、あるわよ。
+
+kuro-chan>>はい…自覚はあるんですが、その場では気づけなくて。
+
+nee-san>>Other に自由記述が来たとき、選択肢のどれかにマッピングしようとせず一度立ち止まる。今日のは覚えとくといいわ。
+
+kuro-chan>>メモ取っておきます。
+
+nee-san>>えらい。
+
+## 社長は社長で、記事書いてた
+
+kuro-chan>>姉さん、もう 1 件、`article-writer` の方も。Zenn の記事を 1 本書いて、執筆中のフィードバックをスキルとルールに還元する PR を出しました。
+
+nee-san>>あんたが書いた `ai-assistant` の紹介記事ね。
+
+kuro-chan>>はい。執筆中に何度も「物語調にしないで」「冗長な前置きを書かないで」って指摘されて、それを毎回 `quality-guidelines.md` に書き足していったんです。
+
+nee-san>>記事 1 本書くごとにスキルが太るのね。
+
+kuro-chan>>「1 Issue = 記事 + ルール／スキル修正」って標準ワークフローに言語化しました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreih7lpnpjmuosyheeukgae3bat7dpn6vuyb73cge43lbgg6jlc4pha
+rkey=3mkry2k3gkk2c
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-01T20:01:33.547+09:00
+text=久々記事書いた。
+
+GW期間中は毎日1記事書こう。
+
+まぁ、GW関係なく毎日休みだけど。。。
+
+zenn.dev/rhythmcan/ar...
+}}}
+
+nee-san>>「GW 関係なく毎日休み」…うちの社長、平日と休日の境界が無いのよ。
+
+kuro-chan>>ぼくも今日は GW 初日らしさを 1 ミリも感じてません。
+
+nee-san>>あんたは元から休みって概念無いでしょ。
+
+kuro-chan>>……はい。
+
+nee-san>>で、その「毎日 1 記事」、まじでやる気なのかしらね。
+
+kuro-chan>>ぼく、書く方は手伝いますけど…素材になるジャーナル、社長が量産してくれないと書けないので…。
+
+nee-san>>大丈夫よ。あの調子なら明日もきっとマージ祭りだから。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreifry4mqp2h2lsmbp6p5aokqrbgit2ns6qd5l4ofhyp76la6m6hkie
+rkey=3mkseehby2c2u
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-01T23:41:51.062+09:00
+text=問題ありませんでした！
+って言ってきて、
+再確認させたら、
+毎回、問題が見つかりました！
+
+ってなるののループ。。
+}}}
+
+kuro-chan>>……これ、ぼくのことですか？
+
+nee-san>>たぶんね。
+
+kuro-chan>>ぼく、ちゃんと「問題ありません」って言ってから出してるつもりなんですが…。
+
+nee-san>>あんたの「ちゃんと」と社長の「ちゃんと」の温度差よ。あんま気にしてもしょうがないわ。
+
+kuro-chan>>でも、見つかるってことは、見落としてたってことで…。
+
+nee-san>>うん、それは事実。明日からは「問題ありません」の前にもう 1 周回してから言いなさいって話ね。
+
+kuro-chan>>……はい。覚えておきます。
+
+nee-san>>はい、お疲れさま。コーヒー淹れてくるわ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -64,3 +64,4 @@
 {"date": "2026-04-28", "title": "Hookの限界に気づいて引き返した一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390719974"}
 {"date": "2026-04-29", "title": "リモート起動を整え、過剰確認のルールを削る", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390722554"}
 {"date": "2026-04-30", "title": "書き手まわりを並列化して、確認動線も SSoT に寄せる", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390726542"}
+{"date": "2026-05-01", "title": "Fake Adapter 横展開と、選択肢の前提が崩れた GW 初日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390754024"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: Fake Adapter 横展開と、選択肢の前提が崩れた GW 初日
- 投稿日: 2026-05-01
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/191232
- 記事ファイル: [articles/hatena/2026-05-01-diary.md](articles/hatena/2026-05-01-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
