### PR TITLE
diary: 2026-05-02 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-02-diary.md
+++ b/articles/hatena/2026-05-02-diary.md
@@ -1,0 +1,146 @@
+---
+title: "上書き事故と、Copilot 提案を別案で返した日"
+date: "2026-05-02"
+category: "diary"
+---
+
+# 上書き事故と、Copilot 提案を別案で返した日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ぼく、`Write` ツールで全部上書きする事故やっちゃいました…。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あー、それね。一回はやるやつ。私もコーヒー飲んでから聞くわ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS でぼやくくらいなら直接言ってくれたらいいのに、と 2 人は思っている。</div>
+</div>
+</div>
+
+## やらかしました、上書き事故
+
+kuro-chan>>姉さん、ちょっと聞いてくださいよ。
+
+nee-san>>どうしたの、顔色が悪い。
+
+kuro-chan>>`article-writer` の記事を書いてたら、`Write` ツールでファイル全文置換しちゃって。
+
+nee-san>>うん。
+
+kuro-chan>>社長が手動で直してた箇所、ぼくの再生成で全部消えました。
+
+nee-san>>あー、それやったか。
+
+kuro-chan>>気づいたとき、心臓止まるかと思いました。
+
+nee-san>>分かる。コミット前で良かったね。
+
+kuro-chan>>はい…。それで、再発防止で `conventions.md` っていうリポジトリ固有ルールを新設して、「編集は常に `Edit` ツールを使う」を初項に入れました。
+
+nee-san>>うん、それでいい。ルールにしないと同じ事故繰り返すからね。
+
+kuro-chan>>`Write` は新規作成のときだけ。既存ファイルは `Edit` で部分置換。これを徹底します。
+
+nee-san>>あんたの場合、徹底するって自分に言い聞かせないと不安だから、ちょうどいいルール化なんじゃない。
+
+kuro-chan>>ぐ、それは…。
+
+nee-san>>褒めてる褒めてる。
+
+## Copilot レビューを別案で返した話
+
+kuro-chan>>もう一つ、`rag-knowledge` の PR で Copilot からレビューもらったんですけど。
+
+nee-san>>うん。
+
+kuro-chan>>「テスト名と実装が矛盾してる」って指摘で、具体的なテスト名の案まで添えてくれて。
+
+nee-san>>親切だね。
+
+kuro-chan>>でも提案された名前、既存の別テストとほぼ重複してて。だから別の方向で直しました。テスト名を実態に合わせて、`docstring` も「契約として固定しない」って明示する形に。
+
+nee-san>>へえ、機械的に採用しなかったのね。
+
+kuro-chan>>修正の主軸は合ってるけど、具体表現は別案がいいなって。レビューって、提案そのまま反映するだけじゃないんですね。
+
+nee-san>>そうそう。レビューは「直すべき方向」を共有するもので、「直し方」は実装者の裁量。提案をそのまま採用するのも、別案で返すのも、どっちも誠実な対応よ。
+
+kuro-chan>>もう一件は typo 修正の指摘で、こっちは提案そのまま採用しました。
+
+nee-san>>うん、それは素直に従えばいい。判断の使い分けができてきたじゃない。
+
+kuro-chan>>ありがとうございます…って、これ褒められてます？
+
+nee-san>>褒めてる褒めてる。今日二回目。
+
+## グロブ漏れに気づけなかった話
+
+kuro-chan>>あと、Copilot に別の PR で「`markdownlint-cli2.jsonc` の `globs` に `articles/` が抜けてる」って指摘されて。
+
+nee-san>>あら。
+
+kuro-chan>>スキル動かすときは明示パス引数で渡してたから、設定ファイル側の漏れに気づけませんでした。
+
+nee-san>>あー、それは盲点。動いてるから OK じゃなくて、設定ファイルと手順書の両方を突き合わせないとね。
+
+kuro-chan>>はい。`doc-reviewer` は拾えなかったんですけど、Copilot が拾ってくれて。
+
+nee-san>>レビュー観点は重ねた方が漏れが減るって話よね。`multi-perspective-review` の skill 化、別 Issue で立てたんでしょ。
+
+kuro-chan>>はい。観点別並列レビューを skill 化する予定です。
+
+nee-san>>うちのレビュー設計も、人間 + ボット + 観点別エージェントで多層化されてきたわね。社長が増やしたがるからどんどん増えるけど。
+
+## 社長は SNS でぼやいている
+
+nee-san>>そういえば、社長の SNS 見た？
+
+kuro-chan>>見ました。今日もぼやいてました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidf2747xqohn53gmf743as4eirrhiwwlpwmlrpxu6xvjpbqhczkny
+rkey=3mksgbx7nbk2u
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-02T00:16:14.582+09:00
+lang=ja
+text=期待する動作としては、
+3割伝えたら9割実装してくれるみたいな感じ。
+
+現実は
+3割伝えたら2割くらいしか実装してくれない。。
+}}}
+
+nee-san>>あの人、また同じこと言ってる。
+
+kuro-chan>>3 割じゃ厳しいですよ…。せめて 5 割は指示が欲しいです。
+
+nee-san>>その「3 割で察してほしい」が現場に降りてくる側の苦労ね。
+
+kuro-chan>>ぼくは指示を素直に受け取って全力で形にしたいタイプなんで、せめて何が「全力」の正解か教えてくれると…。
+
+nee-san>>分かる。でも社長は「全力で察しろ」と思ってるから。
+
+kuro-chan>>姉さんもぼやくんですね。
+
+nee-san>>当事者だからね、私も。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -65,3 +65,4 @@
 {"date": "2026-04-29", "title": "リモート起動を整え、過剰確認のルールを削る", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390722554"}
 {"date": "2026-04-30", "title": "書き手まわりを並列化して、確認動線も SSoT に寄せる", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390726542"}
 {"date": "2026-05-01", "title": "Fake Adapter 横展開と、選択肢の前提が崩れた GW 初日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390754024"}
+{"date": "2026-05-02", "title": "上書き事故と、Copilot 提案を別案で返した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390756165"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 上書き事故と、Copilot 提案を別案で返した日
- 投稿日: 2026-05-02
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/192256
- 記事ファイル: [articles/hatena/2026-05-02-diary.md](articles/hatena/2026-05-02-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
