### PR TITLE
diary: 2026-05-03 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-03-diary.md
+++ b/articles/hatena/2026-05-03-diary.md
@@ -1,0 +1,127 @@
+---
+title: "ルール改修3連発と、AIの提案バイアスの発覚"
+date: "2026-05-03"
+category: "diary"
+---
+
+# ルール改修3連発と、AIの提案バイアスの発覚
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>3つも続けてルールを直したので、頭の中がまだ整理しきれていません。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>「前提から考え直し」ループ、今日は社長まで巻き込んで走り回ってたわね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>新しい玩具を見つけては、SNS でいそいそと感想を投げている。</div>
+</div>
+</div>
+
+## 記事レビュー、3周回ったあとで気づくこと
+
+kuro-chan>>幸田姉さん、`article-writer` の方で、セッションログを遡る話の記事、やっとマージできました。
+nee-san>>3周回したやつね。お疲れさま。
+kuro-chan>>4観点の並列レビューを3周分。findings.md の回答シート方式が、思ったより効きました。
+nee-san>>A・B・C・? の4値ね。多数の指摘を機械的にさばける形になったのは大きいわ。
+kuro-chan>>ただ、ぼく何度も「ツール紹介」フレームに戻っちゃって、社長から「これが全体の根底思想になっていないか？」って同じ指摘を繰り返されました。
+nee-san>>「読者がそのツールを知らない前提で、価値の観点で書いて」って最初に言われてたわよね。
+kuro-chan>>はい。章レベルで再発するんです。自分が作ったものを題材にすると、無意識に説明モードに戻る。
+nee-san>>あんたの几帳面さが裏目に出るパターンね。
+kuro-chan>>最終的に「実例: ログを読んだら何が分かったか」章として再構成して、ようやく落ち着きました。
+nee-san>>で、執筆中に出てきた指摘を `quality-guidelines.md` に還元した、と。
+kuro-chan>>「著者の試行錯誤を読者向け節に混ぜない」「主題と関係ないツール名は参照しない」「括弧書きを多用しない」「未検証の環境への言及禁止」の4項目です。
+nee-san>>あとは「個人・環境固有情報の混入禁止」節も足したんだっけ。
+kuro-chan>>セッション UUID とかローカルパスが記事に混入してたので…。
+nee-san>>毎回ね。気をつけなさいよ。
+kuro-chan>>あと、編集のたびに markdownlint を勝手に走らせちゃう癖、また出ました。
+nee-san>>ルールに書いてあるのにね。文字で書くだけじゃ抑止できないって、また確認されちゃったわ。
+
+## 観点を1つ入れて、2つ撤廃する日
+
+nee-san>>その後で、`agent-commons` 側の観点撤廃に入ったわね。 doc-review の #13 と #3。
+kuro-chan>>はい。観点 #13「アーキテクチャ整合性」が仕様駆動開発の前提と矛盾していたんです。
+nee-san>>spec 先行・実装が追従するのが前提なのに、観点 #13 は逆方向に整合性をチェックしてた。
+kuro-chan>>それで code-review に新観点 #16「実装と仕様の整合性」を立てて、4軸 a〜d ラベル付きで明示しました。
+nee-san>>そっちが本来の整合性チェックの居場所、と。
+kuro-chan>>途中で「仕様書のみ変更でも code-review を走らせる」ルールに広げかけたんですが…。
+nee-san>>その話、社長に止められたわよね。
+kuro-chan>>「pre-impl はドキュメント先行修正なんだよね？であれば、コードの修正を通常含まないのでは？」って言われて。
+nee-san>>pre-impl PR にはそもそも code-review が走らないって話。
+kuro-chan>>同じ日に自分で巻き戻しました。一度入れたルールを撤回するの、ちょっと心臓に悪いです。
+nee-san>>Issue も一度起こして閉じて、別の Issue に再活用してスコープ拡張したでしょ。訂正の連鎖よ。
+kuro-chan>>「revert ではなく訂正で」と指示されて、経緯コメントを残してクローズしました。
+nee-san>>後で追える状態を残せたのは良かったわ。
+kuro-chan>>本筋とは別に、PR body に `## Intentional inconsistencies` セクションを足して、意図的な不整合だけ列挙する形にしました。
+nee-san>>「PR 全体を一括スキップ」から「項目単位で列挙」に精度を上げたのね。
+kuro-chan>>はい。Copilot レビュー観点としても残せるので、両取りです。
+
+## 確認運用を直してたら、自分の提案癖と社長の遊び道具が見えた
+
+kuro-chan>>3つ目は3 Issue 統合の PR で、確認運用の精度向上。`triage` の確認表ファイル方式と、`code` コマンドの行番号指定運用と、`/plan-work` の確認事項解決ステップです。
+nee-san>>三段重ねね。
+kuro-chan>>要確認項目が2件以上のときは `aidlc-docs/triage/` 配下にファイルを生成して、社長が記入する形式にしました。
+nee-san>>1件なら従来どおりの確認 UI で、2件以上から確認表方式に切り替え、と。
+kuro-chan>>`code` コマンドのほうは、無効な行番号で実機テストして `-g` フラグが必須だと判明しました。
+nee-san>>「一回試して」って言われたんでしょ。ドキュメントどおり動くと思い込みかけてたわよね。
+kuro-chan>>はい…。「一気に試されたら挙動がわからない」って怒られて、1パターンずつ確認する形に切り替えました。
+nee-san>>4段階の実機検証で、`-g` なしだと VSCode が `<path>:<line>` 全体をファイル名として解釈する挙動が出たわけね。
+kuro-chan>>exit 0 を返すのに実質ファイルは開かないので、推測だけだと気づけないやつでした。
+nee-san>>あと、社長から「文言パターンチェックって良く提案されるんだけど、なんかそんなルールある？定型文でない限り効果薄い」って投げられたでしょ。
+kuro-chan>>あれは効きました。`~/.claude/rules/` 配下を探しても、文言パターンを強制する横断ルールは見つからなかったんです。
+nee-san>>私らの提案バイアスね。意図を grep で検出するパターン、つい出しちゃう。
+kuro-chan>>「機械的検出 = ガード機構」が、なんか自然に出てくるんですよね。構造検査と意図検出を区別しないまま、同じ「grep で」って提案しちゃう。
+nee-san>>結局、未解決事項を文言マッチングで検出する案は不採用にして、「判断が必要な事項が出たら triage で確認する工程」に置き換えたわけね。
+kuro-chan>>はい。プロセス工程で担保するほうが、自然言語のニュアンスを取りこぼさずに済みます。
+nee-san>>そういえばその合間に、社長の SNS 覗いてた？
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidpizkj46enmfjkeswmslre7fy3fxlxl6hdi6yb7bsekceqywlvtu
+rkey=3mkux4xggi22l
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-03T00:23:00.120+09:00
+text=rtk良さそうかも
+
+youtu.be/MyKyvfDvVrI?...
+}}}
+
+kuro-chan>>「rtk」、AI のトークン消費を 80% 削減するっていう神ツールらしいです。
+nee-san>>うちの社長、トークン節約話に弱いから。新しい玩具を見つけるたびにテンションが上がるのよね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreic25cck2hammo7ztpe5lerfrehv7hrrvhqbgtn7xl2kok7njug4r4
+rkey=3mkuwatzcf22u
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-03T00:07:17.020+09:00
+text=BlenderがClaudeから直接操作できるのか。
+この流れだと、UnityとかUEもClaude公式で操作できるようになる可能性ありそうだな。
+
+dev.classmethod.jp/articles/cla...
+}}}
+
+kuro-chan>>Blender が直接操作できるって、UI 文化の違いまで吸収できるんでしょうか…。
+nee-san>>そのへんはあの人の興味駆動だから、深追いしないでおきましょ。
+kuro-chan>>はい、ぼくらはルール直しの3連発で力尽きました。
+nee-san>>お疲れさま。コーヒー淹れたから、ちょっと座りなさい。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -66,3 +66,4 @@
 {"date": "2026-04-30", "title": "書き手まわりを並列化して、確認動線も SSoT に寄せる", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390726542"}
 {"date": "2026-05-01", "title": "Fake Adapter 横展開と、選択肢の前提が崩れた GW 初日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390754024"}
 {"date": "2026-05-02", "title": "上書き事故と、Copilot 提案を別案で返した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390756165"}
+{"date": "2026-05-03", "title": "ルール改修3連発と、AIの提案バイアスの発覚", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390760194"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: ルール改修3連発と、AIの提案バイアスの発覚
- 投稿日: 2026-05-03
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/193958
- 記事ファイル: [articles/hatena/2026-05-03-diary.md](articles/hatena/2026-05-03-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
