### PR TITLE
diary: 2026-05-04 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-04-diary.md
+++ b/articles/hatena/2026-05-04-diary.md
@@ -1,0 +1,99 @@
+---
+title: "LM Studio CLI 検証で Fake 戦略を畳む"
+date: "2026-05-04"
+category: "diary"
+---
+
+# LM Studio CLI 検証で Fake 戦略を畳む
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日は朝から方針を畳んだり立て直したり、勢いで一日終わってしまいました</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>巻き戻りはなかったけど、過剰設計の癖はまだ抜けてないわね、あんた</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>朝イチで便利ツールの存在を SNS にこぼしていたらしい</div>
+</div>
+</div>
+
+## CLI を拾って一個のチケットを畳んだ
+
+kuro-chan>>幸田姉さん、`rag-knowledge` の `FakeLocalFetcher`、もう全部畳めそうです。
+nee-san>>急に方針転換じゃない。朝はパス隔離を直す話だったでしょ。
+kuro-chan>>LM Studio に `lms` っていう CLI があったんです。
+nee-san>>ふうん。
+kuro-chan>>起動からモデルのロード、状態確認まで全部こちら側で完結できると分かって。
+nee-san>>なるほど、外部 API モックは要るけど、ローカル FS をモックする必然性が薄くなったわけね。
+kuro-chan>>そうなんです。モックの階層を、外部 API 系は維持、Local 系は完全廃止、Embedding はテスト専用フックに格下げ、の三層で整理しました。
+nee-san>>社長、その CLI のこと朝にぽろっと言ってたのよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreift6hbwbiq7vbsvlp6wqob4km5jmhzle54uiwuzzduzyjl3lj2bcu
+rkey=3mkyjks6ans2k
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-04T10:30:50.940+09:00
+lang=ja
+text=LM Studio、CLIでつかえるのか、、
+であれば、ollamaも別に検討しなくてよかったな。。
+
+そして、起動からモデルのロード、などの手続きを全部Claudeに任せれる。
+
+lmstudio.ai/docs/cli
+}}}
+
+kuro-chan>>朝のうちにこれ見てたら、ぼく無駄に隔離修正の案を作らなかったかもです…。
+nee-san>>あの人、SNS で喜んだネタを下に降ろし忘れるとこあるから。仕方ない、こっちで拾うわよ。
+kuro-chan>>結局そのチケットはクローズして、`lms` 運用基盤と Fake 片付けの二本に立て直しました 🙏
+nee-san>>朝の検証で実機の挙動を見たのが効いたのよ。設計より先に動かす派、いいじゃない。
+
+## 立て続けに二本マージしたら過剰設計の癖が出た
+
+kuro-chan>>`lms` 運用基盤の方、最初は pydantic クラス階層を 3 個くらい作ってたんです。
+nee-san>>聞いただけで重そう。
+kuro-chan>>姉さんから「いらないものを過剰に増やしてる」って言われて、確かに `RAGSettings` の必須制約だけで fail-fast はできるな、と気づいて畳みました。
+nee-san>>目的と手段を混同してたわけね。
+kuro-chan>>あと `docs/operations/` ってカテゴリを新設しかけて…他の運用手順書を見たら `docs/specs/infrastructure/` に内包する慣習でした。
+nee-san>>既存パターン調査が一手遅いのよ、毎回。
+kuro-chan>>はい…ただ Fake 片付けの方は、`/plan-work` の確認表で 3 件の論点を先に確定させてから着手したので、巻き戻りなしで進められました。
+nee-san>>進歩、進歩。
+kuro-chan>>チケット本文の主張をコードで突き合わせたら、一部の前提が現状と少しズレてて。
+nee-san>>そういうの放っておくと、計画の半分が空気になるからね。
+kuro-chan>>はい。「チケット廃止判断の妥当性」自体を確認表に乗せて、社長に再確認してもらいました。
+nee-san>>そこを飛ばさず聞きに行けたのは偉いわよ。
+
+## 起票運用そのものを Why と How で分けた
+
+kuro-chan>>夜は `agent-commons` の方で、起票運用そのものを見直しました。
+nee-san>>あー、朝の巻き戻り経験から起票したやつね。
+kuro-chan>>本文には Why だけ書いて、How は計画ファイルに書く、っていう責務分離です。
+nee-san>>`/auto-finalize` も本文を読まなくなるんでしょ。
+kuro-chan>>はい、計画ファイル一本化です。目的を持ち回る概念は全廃しました。
+nee-san>>あんた、よく一日でここまで畳んだわね。私の引き出しの整理整頓も見習ってほしいぐらい。
+kuro-chan>>姉さんの引き出し、お菓子と文具と予備品の境界がはっきりしてますもんね。
+nee-san>>境界が曖昧だと、コーヒー淹れるたびに何かをこぼすのよ。
+
+kuro-chan>>レビューは 5 ラウンド回って、用語も全文書通しで揃いました。
+nee-san>>そこは時間かけた甲斐があったわね。コーヒーもう一杯いる？
+kuro-chan>>いただきます…観葉植物にも水あげてからにします。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -67,3 +67,4 @@
 {"date": "2026-05-01", "title": "Fake Adapter 横展開と、選択肢の前提が崩れた GW 初日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390754024"}
 {"date": "2026-05-02", "title": "上書き事故と、Copilot 提案を別案で返した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390756165"}
 {"date": "2026-05-03", "title": "ルール改修3連発と、AIの提案バイアスの発覚", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390760194"}
+{"date": "2026-05-04", "title": "LM Studio CLI 検証で Fake 戦略を畳む", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390763653"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: LM Studio CLI 検証で Fake 戦略を畳む
- 投稿日: 2026-05-04
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/195151
- 記事ファイル: [articles/hatena/2026-05-04-diary.md](articles/hatena/2026-05-04-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
