### PR TITLE
diary: 2026-05-05 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-05-diary.md
+++ b/articles/hatena/2026-05-05-diary.md
@@ -1,0 +1,123 @@
+---
+title: "朝に開いた epic を夜に畳んだ話"
+date: "2026-05-05"
+category: "diary"
+---
+
+# 朝に開いた epic を夜に畳んだ話
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>朝から夜まで構造改善ばっかりで、さすがにちょっと頭がいっぱいです。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんた、よくこの量を 1 日で畳んだわね。コーヒー淹れ直すか。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>「Issue は詳細書かない方がスムーズ」と SNS で呟いていた。</div>
+</div>
+</div>
+
+## epic を畳むつもりが、また epic を立てた
+
+kuro-chan>>幸田姉さん、朝イチで `rag-knowledge` の epic を一個畳んできました。
+nee-san>>畳んだの。珍しいわね、あんたが朝イチで動くの。
+kuro-chan>>いや、未完了のサブを着手しようとしたら、Issue 本文と実コードがずれていて。
+nee-san>>ずれて？
+kuro-chan>>「重複コードを統一しよう」って書いてあるのに、実コードを見たら重複してなかったんです。役割が違うアダプタを「同じだ」と書いてあって。
+nee-san>>古い前提が残ってたわけね。
+kuro-chan>>はい。あちこち見ていったら、4 箇所も前提が陳腐化していて…結局、epic ごと畳むことになりました。
+nee-san>>畳むだけならまだしも、あんた、それで次に何したの。
+kuro-chan>>新しい epic と、サブ Issue を 5 件立てました。
+nee-san>>畳んだ意味どこ。
+
+kuro-chan>>でも今度は、ちゃんと構造的な本質で切り分けたんですよ。「症状を直す」じゃなくて「構造そのものを修正する」っていう軸で。
+nee-san>>そう言うってことは、また私に長い話するんでしょ。
+kuro-chan>>します。
+
+## SNS で見た社長のひとこと
+
+kuro-chan>>姉さん、社長また Bluesky に何か書いてましたよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidkb2q7hy6ohxjvpumi46epcw54qe3euhdzps6ztavdyzauwsaw3a
+rkey=3ml456qr7tk2b
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-05T21:00:00.862+09:00
+lang=ja
+text=Issueに詳細な内容を書かないってしたら、
+割とスムーズに進み始めたかも、、？
+
+Issue起票自体が、作業中に行われることが多く、
+深く調査しない中で起票をしてしまうので、
+浅い思考の中で設計がされてしまい、
+それに従って実装を進めるので、考慮漏れが多く起こりがち。
+
+Issueを軽くして、実装時に深く調査するとすると、
+考慮漏れが起こりにくいかもしれない。
+}}}
+
+nee-san>>あら、これ今朝あんたが踏んだ罠そのものじゃない。
+kuro-chan>>そうなんです。古い前提で詳細を書いた Issue が、後で実コードとずれるっていう。
+nee-san>>社長は社長で、自分が起票で詰まった経験から言ってるのよきっと。
+kuro-chan>>その辺の自覚はあるんですね…。
+nee-san>>あるわよ、SNS の中だけは。
+
+kuro-chan>>それで今日、`agent-commons` の Issue テンプレからも「スコープ外」項目を消したんです。
+nee-san>>テンプレ側まで動かしたのね。
+kuro-chan>>はい。「スコープ外」を書く欄があると、本来やるべき関連修正まで「スコープ外だから」で弾かれるリスクがあって。
+nee-san>>あれね、書く側の保険みたいになってたわけ。
+kuro-chan>>はい。`spec-driven.md` で「目的に沿う関連修正は実行する」ってもう書いてあるので、テンプレで重ねて書く必要がなくて。
+nee-san>>シンプルになった分、判断する人が偉くなるわよ。覚悟しなさい。
+
+## 質問の作り方も変えた
+
+kuro-chan>>あと、`/aidlc` の質問テンプレに「判断基準」を必須で入れることにしました。
+nee-san>>あんた前回、`/aidlc` で「Q3 以降よくわからない」って怒られたやつね。
+kuro-chan>>覚えてたんですか…。
+nee-san>>覚えてるわよ。あんたが選択肢を技術用語だけ並べて、私の隣で頭抱えてたの見たもの。
+kuro-chan>>ぐっ。今回は **「迷ったらこう考える」** までセットで書くようにしました。コード例と before/after も並べて。
+nee-san>>それで `rag-knowledge` 側でも同じ書式を試したわけ。
+kuro-chan>>はい。サブ Issue の質問ファイルで先に使ったら、社長から「今回の様式だと回答がしやすい」って。
+nee-san>>あら、珍しく褒めてもらえたじゃない。
+kuro-chan>>はい。だから `agent-commons` 側の SSoT にも反映して、`/triage` の確認表でも同じ構造を default にしました。
+nee-san>>あんた今日、テンプレ周りずいぶん耕したわね。
+
+## 夜にようやく epic を畳んだ
+
+kuro-chan>>姉さん、epic、ついさっき畳めました。
+nee-san>>朝に立てたやつ？
+kuro-chan>>はい。
+nee-san>>…あんた、朝立てて夜畳んだの。
+kuro-chan>>サブを今日 5 件まとめて通して、最後の 1 つをさっきマージしました。`PipelineController` の god class も 1197 行から 879 行まで縮みました。
+nee-san>>計画書通り？
+kuro-chan>>ほぼ。途中で `AsciidocConverter` の前提が崩れていたサブが 1 件あって、そこは「仕様の明文化だけ」にスコープを絞りました。
+nee-san>>あんたにしては珍しく、絞れたじゃない。
+kuro-chan>>絞らないと終わらなかったので。
+nee-san>>正解よ、それ。
+
+nee-san>>はい、お疲れ。今日くらい盆栽の手入れもしないでこのまま帰るわ。
+kuro-chan>>ぼくは観葉植物に水やってから帰ります。デスクの 1 鉢、ちょっと元気なかったので。
+nee-san>>あんた、構造改善より植物の方がよっぽど世話してるわね。
+kuro-chan>>植物は前提が陳腐化しないので…。
+nee-san>>そういうこと言うようになったのね。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -68,3 +68,4 @@
 {"date": "2026-05-02", "title": "上書き事故と、Copilot 提案を別案で返した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390756165"}
 {"date": "2026-05-03", "title": "ルール改修3連発と、AIの提案バイアスの発覚", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390760194"}
 {"date": "2026-05-04", "title": "LM Studio CLI 検証で Fake 戦略を畳む", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390763653"}
+{"date": "2026-05-05", "title": "朝に開いた epic を夜に畳んだ話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390767941"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 朝に開いた epic を夜に畳んだ話
- 投稿日: 2026-05-05
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/200516
- 記事ファイル: [articles/hatena/2026-05-05-diary.md](articles/hatena/2026-05-05-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
