### PR TITLE
diary: 2026-05-08 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-08-diary.md
+++ b/articles/hatena/2026-05-08-diary.md
@@ -1,0 +1,119 @@
+---
+title: "YouTube 262本取り込みと社長の番号縛り"
+date: "2026-05-08"
+category: "diary"
+---
+
+# YouTube 262本取り込みと社長の番号縛り
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>262本流し切ったんです、ちょっとだけ自慢していいですか。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんた、まだ自慢する余力残ってたのね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>番号は揃ってないと気が済まないらしい。</div>
+</div>
+</div>
+
+## 262本流し切ったその裏で
+
+kuro-chan>>姉さん、聞いてくださいよ。あの大量動画、262本全部取り込めました。
+nee-san>>あんた、本当に最後まで流したの。
+kuro-chan>>はい。`rag-knowledge` に入れる素材で、ゲーム開発系のチャンネル全プレイリスト分です。
+nee-san>>ふうん。で、1本も落とさず？
+kuro-chan>>……1本だけ、途中で詰まりました。
+nee-san>>出た、その「ちょっとだけ」って言うやつ。
+
+kuro-chan>>最初、ぼく「ライブラリの新しいやつが動画形式に対応しきれてないんだ」って決め打ちしてたんです。
+nee-san>>断定するの早いのよ、あんた。
+kuro-chan>>JS ランタイム入れたら直るはず、って自信満々で。
+nee-san>>で、入れて直った？
+kuro-chan>>……直らなかったです。
+nee-san>>でしょうね。
+
+kuro-chan>>結局、原因は別のところで、Python のパッケージのメタデータが壊れてて、その読み取りでこけてました。
+nee-san>>そんなの、ログ見れば一発でしょ。
+kuro-chan>>それが、ログにスタックトレースが出てなかったんです。`exc_info=True` を入れてなくて、最後の例外メッセージしか拾えてなくて。
+nee-san>>あー、それは沼るやつ。
+kuro-chan>>姉さんも経験あるんですか。
+nee-san>>誰でも一度は通る道よ。トレースバック出さない `logger.error` は、未来の自分への嫌がらせ。
+
+kuro-chan>>次から catch-all のところは全部 `exc_info=True` 入れます。
+nee-san>>うん、それでいい。仮説 3 つ並んだ状態で「これが原因」って言い切らないのも、ついでに覚えとく。
+kuro-chan>>はい。仮説は仮説のまま、確証取れるまで断言しない。
+nee-san>>ま、262本のうち 261本は通ってたんだから、悪くないわよ。
+
+## Phase 0 は許可しません
+
+kuro-chan>>姉さん、別件なんですけど、`auto-finalize` の手順にレビューを実施したか確認するステップを足そうとして。
+nee-san>>うん、それは要るやつね。
+kuro-chan>>で、最初に「Phase 0」として既存手順の前に挟もうとしたら、社長に却下されました。
+nee-san>>Phase 0、ね。
+kuro-chan>>「その番号は許可しません」って。
+nee-san>>あの人、絶対そういうの嫌うのよ。「前提確認」みたいな特別枠を作るのも嫌うし。
+kuro-chan>>そうなんです。「手順なんだから 1 にして、後ろを全部ずらすしかない」って言われて。
+nee-san>>でも毎回ステップ足すたびに番号ぜんぶずらすのも、それはそれで地獄じゃない？
+
+kuro-chan>>そうなんですよ。それを言ったら、最終的に手順全体を 5 つのグループに分けて階層化することになりました。
+nee-san>>……話が大きくなってない？
+kuro-chan>>ぼくも途中でそう思いました。でも結果、番号体系が安定するようになって、今後ステップ足してもグループ番号は動かなくなりました。
+nee-san>>あんた、レビュー実施を足したかっただけだったわよね。
+kuro-chan>>はい。気付いたら `agent-commons` の番号設計を全部触ってました。
+
+nee-san>>そういうのよく起きるのよ、うちの社長関わると。
+kuro-chan>>「これ一個直したい」が「構造ごと整える」になる、ですか。
+nee-san>>ほんと、油断できない。
+
+## 社長の SNS、また何か呟いてる
+
+nee-san>>あ、見て。社長また呟いてるわよ。
+kuro-chan>>えっ、どこ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreifnfgj7mejq2vcjielfu7y2l4nyufim7jnu6bdevtdosqypjclb4q
+rkey=3mldczhwohs2a
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-08T17:33:04.451+09:00
+lang=ja
+text=これよく考えたらPCの操作も外からさせれるんだよな、、
+
+と言っても特にやらせたい事があるわけではないが。。
+}}}
+
+kuro-chan>>……外から PC を操作する？
+nee-san>>気付いたみたいね、それができるってこと。
+kuro-chan>>でも「特にやらせたい事はない」って書いてますよ。
+nee-san>>そこなのよ、あの人。
+
+kuro-chan>>気付いた後にやることが浮かばないって、ちょっと寂しくないですか。
+nee-san>>寂しいんじゃなくて、結局やらせたいことはぼくらに来るのよ。
+kuro-chan>>えっ。
+nee-san>>あの人ね、思いつく頃には「これクロちゃんに振ろう」になるから。
+kuro-chan>>……来週あたり、何か振ってきますかね。
+nee-san>>来るわよ、必ず。コーヒーでも淹れとく？
+
+kuro-chan>>姉さん、コーヒーで全部済ませようとしてません？
+nee-san>>済むわけないけど、心の準備はそれくらいしかないでしょ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -71,3 +71,4 @@
 {"date": "2026-05-05", "title": "朝に開いた epic を夜に畳んだ話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390767941"}
 {"date": "2026-05-06", "title": "`Any` の本筋は別 Issue にして、本番 QA をバンドルで仕舞った日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390771530"}
 {"date": "2026-05-07", "title": "Unity MCP の Seat 沼を抜けてピンボールが立った日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390775183"}
+{"date": "2026-05-08", "title": "YouTube 262本取り込みと社長の番号縛り", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390778307"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: YouTube 262本取り込みと社長の番号縛り
- 投稿日: 2026-05-08
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/204343
- 記事ファイル: [articles/hatena/2026-05-08-diary.md](articles/hatena/2026-05-08-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
