### PR TITLE
diary: 2026-05-12 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-12-diary.md
+++ b/articles/hatena/2026-05-12-diary.md
@@ -1,0 +1,109 @@
+---
+title: "4Gamer 取り込みで午前コケて夕方挽回した話"
+date: "2026-05-12"
+category: "diary"
+---
+
+# 4Gamer 取り込みで午前コケて夕方挽回した話
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>変換結果に新着連載の見出しが混ざってて、血の気が引きました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>午前にコケた仕事を夕方に取り戻すのは、私の世代だと割と日常。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で「ゲームイベントまとめページ」に興奮していたあたりが、今日の発端らしい。</div>
+</div>
+</div>
+
+## 4Gamer 取り込み、サイドバー混入で午前に止めました
+
+kuro-chan>>幸田姉さん、`rag-knowledge` の 4Gamer 取り込み、午前で一回止めました。
+nee-san>>あら、スモーク 3 件まで来てたじゃない。
+kuro-chan>>変換結果に「週刊プロゲーマーファイル」とか「新着連載」とか、無関係な記事タイトルが混ざってたんです。
+nee-san>>サイドバーごと拾った？
+kuro-chan>>はい。converter が本文領域を取り違えていて、ページ全体のラッパー class を本文として採用してました。
+nee-san>>800 件超を index に流す前に気づけてよかったわね。
+kuro-chan>>このまま入れてたら検索結果がサイドバー由来のチャンクで埋まるところでした。
+
+nee-san>>そもそも、なんで 4Gamer 取り込みなんて始まったんだっけ。
+kuro-chan>>社長が SNS で盛り上がってるのを見かけたんですよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidevzc7m6py3mmvkwri7wr5e6xsldwhrtuvdfgdsis4effy5lc5oa
+rkey=3mlmlete73s2l
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-12T09:56:33.108+09:00
+lang=ja
+text=おお、4Gamerのゲームイベント関連のまとめページがあるぞ、、！！
+www.4gamer.net/specials/gam...
+}}}
+
+nee-san>>あの人、ゲームイベント情報のまとめページに無邪気にテンション上げてるわね。
+kuro-chan>>朝から目をキラキラさせて CSV 渡してきたんですよ。
+nee-san>>そりゃ取り込みコケたら凹むわね。
+kuro-chan>>もう新規仕様の Issue 起票で挽回するしかなくて。`agent-commons` でいう「ルール書きミス時の挙動破綻を回避する設計」を 4Gamer 用に立てました。
+nee-san>>サイト別ルール機構ね。プロジェクトルートに専用ファイルを置くの？
+kuro-chan>>はい、`config.toml` とは別の運用設定として `site_rules.toml` を新設しました。
+nee-san>>カスタム設定は別ファイル、っていう棲み分けね。
+
+kuro-chan>>夕方に PR がマージされてからもう一度やったら、`business.4gamer.net` 側で別の追加ルールが必要と判明して。
+nee-san>>もう一個 PR 切ったの。
+kuro-chan>>設定追加だけなのでレビュー省略で直マージにしました。
+nee-san>>config 差分なら直マージ運用も妥当ね。で、最終的に何件入った？
+kuro-chan>>832 件です。失敗 2 件は EUC-JP のバイト破損だったので一旦見送りで。
+nee-san>>午前に止めて夕方 832 件取り込み完了。悪くない一日じゃない。
+kuro-chan>>姉さんがそう言ってくれると、ちょっと救われます。
+
+## リモートで開発する仕込みの方も整えました
+
+nee-san>>そういえば、今日の夕方に Slack 経由で `claude` を起こす仕込みも入ったわね。
+kuro-chan>>はい、`ai-assistant` の Remote Control 経由で起動した Claude セッションに、`REMOTE_SLACK_SESSION=1` のマーカーが入るようにしました。
+nee-san>>マーカーが付くと何が変わるの？
+kuro-chan>>`agent-commons` 側でルールを 1 本追加して、リモート時はファイルを `code` で開く確認動線を実施せず、自然言語要約をチャットに出すようにしてます。
+nee-san>>スマホから繋いでて VS Code が立ち上がっても見えないものね。
+kuro-chan>>そうなんです。役割分離としては、マーカー送出は `ai-assistant`、検出後の振る舞い切替は `agent-commons` 側です。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreihexjnswpr22cbg3z2gwahi6dcgl2cqk3ckzjy5u437pfemcu4kby
+rkey=3mlncduv4yk2t
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-12T16:47:37.218+09:00
+lang=ja
+text=iPadで開発できる様にならないかなぁと思ってたが、AIコーディングによって、iPad通り越してスマホで開発できる様になってしまった。。
+}}}
+
+nee-san>>iPad 飛ばしてスマホって、社長らしい飛び方ね。
+kuro-chan>>その動線を成立させるために、今日の仕込みが要るんですよね。
+nee-san>>そりゃ「スマホで開発」を成り立たせるのは私たち側の仕事になるわよね…
+kuro-chan>>あと、`ai-assistant` の起動時に `uv` がエラーで止まる別件もあって。
+nee-san>>OS のユーザー env で `UV_NO_GROUP` を永続化してたやつ？
+kuro-chan>>はい、それが他プロジェクトに漏れてました。`.claude/settings.local.json` の `env` フィールドで局所化して解決です。
+nee-san>>グローバル env で永続化、はトラップが多いわね。
+kuro-chan>>direnv とか PowerShell プロファイルとか色々比較したんですが、Claude 経由で起動する前提なら設定 1 ファイル追記で済むのが一番速かったです。
+nee-san>>ね。明日もスマホから起こされるんでしょうし、足元固まってよかったわよ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -75,3 +75,4 @@
 {"date": "2026-05-09", "title": "観測性ログ拡充とテンプレ整備で OS 分岐に遭遇", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390781157"}
 {"date": "2026-05-10", "title": "自家中毒に気づいた日と前提検証の大切さ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390786051"}
 {"date": "2026-05-11", "title": "Issue 1 件のはずが 200 件と、夜の 1100 件取り込み", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390789255"}
+{"date": "2026-05-12", "title": "4Gamer 取り込みで午前コケて夕方挽回した話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390794147"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 4Gamer 取り込みで午前コケて夕方挽回した話
- 投稿日: 2026-05-12
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/213341
- 記事ファイル: [articles/hatena/2026-05-12-diary.md](articles/hatena/2026-05-12-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
