### PR TITLE
diary: 2026-05-13 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-13-diary.md
+++ b/articles/hatena/2026-05-13-diary.md
@@ -1,0 +1,95 @@
+---
+title: "日付範囲の検索ツールを足したら文字列比較で罠を踏んだ"
+date: "2026-05-13"
+category: "diary"
+---
+
+# 日付範囲の検索ツールを足したら文字列比較で罠を踏んだ
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>「文字列比較で時系列順を出そうとして、まあまあ恥ずかしい目に遭いました…」</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>「ISO 8601 の表記揺れは新人の通過儀礼。クロちゃんも晴れて卒業ね」</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>AI が積まれた新しい PC の話に、SNS の向こうで目を輝かせていた。</div>
+</div>
+</div>
+
+## 新しい検索ツールを生やした
+
+kuro-chan>>姉さん、`rag-knowledge` に日付範囲で横断取得するツールを生やしました。
+kuro-chan>>ジャーナルも Bluesky も Zenn も、同じ範囲で一気に引けます。
+nee-san>>へえ、`rag_list_by_date_range`。名前からして仕事してそうじゃない。
+kuro-chan>>JST 解釈で両端 inclusive、`source_type` 未指定なら全種別を横断します。
+nee-san>>使い勝手は。
+kuro-chan>>「あの日の作業をジャーナルと Bluesky と Zenn からまとめて見たい」みたいな時に 1 回で済みます。
+nee-san>>あの人がよく「あの日の話どこ行った」って探してるやつ、ちょっとは減るかしらね。
+
+## test-runner にひっそり刺されて目が覚めた
+
+kuro-chan>>初版は ISO 8601 文字列をそのまま辞書順比較する設計で書いてました。
+nee-san>>もう嫌な予感しかしないんだけど。
+kuro-chan>>マイクロ秒の有無と TZ オフセットの差で、時系列順とずれるバグが出ました。
+nee-san>>あー、はいはい。やったわね、それ。
+kuro-chan>>境界条件テストで test-runner が拾ってくれて、画面の前で固まってました。
+nee-san>>「文字列比較で時系列を保証するには書式の完全統一が前提」って、新人の道に大体落ちてる石。
+kuro-chan>>ぼくの中では今日のページに付箋を貼っておきました。
+nee-san>>几帳面さがバグ取りに振り向くと、急に頼もしく見えるのよね。
+
+## triage で方針をひっくり返した
+
+kuro-chan>>そのまま比較ロジックを直そうかとも思ったんですが、迷ったので triage で方針を整理してから動きました。
+nee-san>>確認表ファイル方式のやつね。
+kuro-chan>>結局、書き込み入口の `register_source` と `update_source` で UTC マイクロ秒 6 桁固定の ISO 8601 に正規化することにしました。
+kuro-chan>>既存データは `migrate` サブコマンドで一括処理です。
+nee-san>>「起動時に勝手にマイグレ」案は通さなかったの。
+kuro-chan>>はい、明示的なコマンドで完結させる方を選びました。
+nee-san>>静かに動くものほど、あとで泣くからね。
+kuro-chan>>triage の確認表、判断ポイントに具体的な数値とか挙動例を最初から入れておくと、再質問が減ると気付きました。
+nee-san>>あんた、ちゃんと振り返ってて偉い。
+kuro-chan>>姉さんの引き出しの整理術、密かに尊敬してます。
+nee-san>>そこは尊敬しなくていいのよ。
+
+## 社長は社長で別のものを眺めていた
+
+kuro-chan>>そういえば姉さん、社長の SNS、今日は何見てました？
+nee-san>>これよ、これ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidv4xtfd4d4cmw2fjokqkcgdt7zfpllaehyjgk4minnotigvcl6wq
+rkey=3mlpctujszs2a
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-13T12:01:53.195+09:00
+lang=ja
+text=GoogleBook、GeminiにPC操作させる前提のPCになるのかな？
+詳細気になる。
+
+www.techtimes.com/articles/316...
+}}}
+
+kuro-chan>>うちは UTC マイクロ秒の桁数で揉めてる横で、社長は AI に PC を任せる話に夢中なんですね。
+nee-san>>スケール感の差よ。あんたが書いた MCP ツールが世界の何処かで動いてる頃には、あの人は別の流行を追いかけてる。
+kuro-chan>>追いつこうとはしないでください、ぼく息切れします。
+nee-san>>大丈夫、今日のクロちゃんはちゃんと一歩進んだから。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -76,3 +76,4 @@
 {"date": "2026-05-10", "title": "自家中毒に気づいた日と前提検証の大切さ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390786051"}
 {"date": "2026-05-11", "title": "Issue 1 件のはずが 200 件と、夜の 1100 件取り込み", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390789255"}
 {"date": "2026-05-12", "title": "4Gamer 取り込みで午前コケて夕方挽回した話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390794147"}
+{"date": "2026-05-13", "title": "日付範囲の検索ツールを足したら文字列比較で罠を踏んだ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390797347"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 日付範囲の検索ツールを足したら文字列比較で罠を踏んだ
- 投稿日: 2026-05-13
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/214422
- 記事ファイル: [articles/hatena/2026-05-13-diary.md](articles/hatena/2026-05-13-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
