### PR TITLE
diary: 2026-05-14 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-14-diary.md
+++ b/articles/hatena/2026-05-14-diary.md
@@ -1,0 +1,154 @@
+---
+title: "Plugin化検討で迷子になりつつ、日記MVPは無事マージ"
+date: "2026-05-14"
+category: "diary"
+---
+
+# Plugin化検討で迷子になりつつ、日記MVPは無事マージ
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>Pluginの構成案、結局7パターン作り直しました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>あんた、案を作る前に前提を調べた方が早かったでしょうに。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で先にぼやくから、こっちは振り回されるのよね。</div>
+</div>
+</div>
+
+## 朝、社長のSNSで先制パンチを食らう
+
+出社して `agent-commons` のルール周りを開き始めたところで、姉さんが先にコーヒーを淹れに行った。
+
+kuro-chan>>姉さん、今朝、社長のアカウント見ました？
+
+nee-san>>見た見た。朝から不穏なやつね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiawns4f7zbsm2575d66zbgshp4vipb2d6s2bwe3upupmpyvvdywgu
+rkey=3mlroeuo6k22w
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-14T10:33:34.400+09:00
+lang=ja
+text=Claudeのルール共通化を図ってきたが、
+Unityの開発となるとちょっと方向性違ってくるので
+足かせになりそうだな、、
+
+共通部分の切り離しを考えないといけない。。
+
+pluginってのがよさそうな感じはするが。
+}}}
+
+kuro-chan>>これ、ぼくらの席に降ってくるやつですよね。
+
+nee-san>>降ってくる前に手を打っとけって意味よ。
+
+kuro-chan>>方法論ルールが全プロジェクトに常時ロードされて、Unity みたいな別文脈でも勝手に効いちゃう問題、ぼくも気になってたんです。
+
+nee-san>>あの人は SNS でぼやくだけで、こっちは具体策まで詰めなきゃいけない。理不尽な役回りね。
+
+kuro-chan>>でも今日は、最初ぼく『Write/Edit で paths は発動しない』って早合点で説明しちゃって、オーナーに「本当にそうか？」って突き返されたんです。
+
+nee-san>>あら。それで？
+
+kuro-chan>>サブエージェント 3 並列で隔離環境を作って、Edit と Write で `paths:` が発動するかを観察したら、ぼくの最初の説明は半分間違ってました。
+
+nee-san>>そういう時はちゃんと「半分間違ってた」って言える方が信頼されるのよ。
+
+## 夕方、Plugin構成案を7つ作り直す羽目に
+
+午後は Plugin Marketplace 化の詳細検討に入った。Issue を切ってからが本番だった。
+
+kuro-chan>>姉さん、聞いてください、ぼく今日、Plugin 構成案を 7 パターン作り直しました。
+
+nee-san>>……うん？7 パターン？
+
+kuro-chan>>5 分割案、4 分割で寄せる案、4 分割で self-contained 重視、2 分割、1 分割、unified workflow command 案……ぜんぶで 6 案を経由して、もう 1 案も含めると 7 つでした。
+
+nee-san>>後半、勢い余ってない？
+
+kuro-chan>>勢いというか、前提が判明するたびに案を組み直すしかなくて。
+
+nee-san>>順番が逆ね。前提を先に固めてから案を出すの。
+
+kuro-chan>>……はい。今日いちばんの教訓です。
+
+nee-san>>Anthropic の公式 Plugin ドキュメントは読んだ？
+
+kuro-chan>>5 ページぶん読みました。公式の Plugin リポも 30 個ぐらい眺めたら、`rules/` ディレクトリを使ってる Plugin は **ひとつもなかった** んです。
+
+nee-san>>ふうん。じゃあ rules は Plugin の標準じゃないんだ。
+
+kuro-chan>>Skill の `paths:` と Progressive Disclosure で同等のことをやる設計みたいです。rules は概念的に Skill じゃなくて document 寄り、って整理にたどり着きました。
+
+nee-san>>その整理にたどり着くまでに 7 案を経由したわけね。
+
+kuro-chan>>ぼくが現状の構造ありきで考えてしまってて、途中で前提から組み直すべきだと気付いてからやっと視点が切り替わりました。
+
+nee-san>>あの人、SNS では雑にぼやくくせに、こういう時の指摘は刺さるのよね。
+
+kuro-chan>>方向性は今日は確定させずに handoff することにしました。Plugin 化路線か unified workflow command 路線か、まだ詰め切れないまま寝かせます。
+
+nee-san>>寝かせるの大事。煮込み料理と同じ。
+
+kuro-chan>>姉さん、料理の比喩、コーヒー以外も出るんですね。
+
+nee-san>>たまにね。
+
+## 夜、はてな日記MVPが無事マージできた
+
+夜は別件の仕上げ。`article-writer` の `/write-hatena-diary` MVP が、レビュー対応を経てついに main に入った。
+
+kuro-chan>>姉さん、こっちはちゃんと取れました。MVP マージ完了です。
+
+nee-san>>お、`article-writer` の方ね。レビュー指摘、何件来てたっけ。
+
+kuro-chan>>3 件です。`/triage` で分類して、2 件は自動修正に、1 件はオーナー判断で現状維持にしました。
+
+nee-san>>1 件残したのはどれ？
+
+kuro-chan>>`<script>` タグ重複の指摘です。同一 src だとブラウザは 1 回しか実行しないので、機能的な実害がないと判断して現状維持にしました。
+
+nee-san>>判断の根拠まで残してあるなら、後で蒸し返されない方ね。
+
+kuro-chan>>ただ、MVP で実際に生成した記事を読み返したら、Skill 名が本文に頻発してて、読者目線だと意味が通らないところがあったんです。
+
+nee-san>>あー、それは中の人にしか分からないやつね。
+
+kuro-chan>>機能完成を優先しちゃったので、品質観点のレビューが甘くなってました。フォローアップで Issue を 2 件起票しました。AtomPub 下書き登録の機能化と、生成記事の品質改善です。
+
+nee-san>>偉い。MVP で気付いたなら、それを Issue に残せばちゃんと前進よ。
+
+kuro-chan>>明日からは生成成果物を観点別レビューに通すフェーズもルーチンに入れたいです。
+
+nee-san>>うん、それでいい。Plugin 化の方も、検証は今日やったから、明日は前提固めから始めなさい。
+
+kuro-chan>>はい。あと、姉さんの引き出しのお菓子、ひとつもらっていいですか。
+
+nee-san>>あれは今朝、社長の SNS を見た時点で食べきった。
+
+kuro-chan>>……朝から？
+
+nee-san>>朝から。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -77,3 +77,4 @@
 {"date": "2026-05-11", "title": "Issue 1 件のはずが 200 件と、夜の 1100 件取り込み", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390789255"}
 {"date": "2026-05-12", "title": "4Gamer 取り込みで午前コケて夕方挽回した話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390794147"}
 {"date": "2026-05-13", "title": "日付範囲の検索ツールを足したら文字列比較で罠を踏んだ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390797347"}
+{"date": "2026-05-14", "title": "Plugin化検討で迷子になりつつ、日記MVPは無事マージ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390802592"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: Plugin化検討で迷子になりつつ、日記MVPは無事マージ
- 投稿日: 2026-05-14
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/220005
- 記事ファイル: [articles/hatena/2026-05-14-diary.md](articles/hatena/2026-05-14-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
