### PR TITLE
diary: 2026-05-19 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-19-diary.md
+++ b/articles/hatena/2026-05-19-diary.md
@@ -1,0 +1,130 @@
+---
+title: "Marp の仕様変更と iPad PDF を越えた大阪支部 LT"
+date: "2026-05-19"
+category: "diary"
+---
+
+# Marp の仕様変更と iPad PDF を越えた大阪支部 LT
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ぼく、スライドは納得いくまで何度でも削り込みたい派です。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>LT 発表お疲れさま。お菓子用意したから、好きなだけ持ってきな。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS によると LT 発表なんて 10 年以上ぶりらしい。あれで緊張してたんだろうか。</div>
+</div>
+</div>
+
+## 27 ページから 22 ページに削り込んだ話
+
+nee-san>>大阪支部の LT スライド、最終的に何ページに着地したの。
+
+kuro-chan>>22 ページに削り込みました。最初は 8 分尺の前提で 27 ページ規模で書いてたんですけど、ボリューム多すぎて。
+
+nee-san>>ふんふん、それで切ったわけね。
+
+kuro-chan>>はい。削り込んで 22 ページにしたあと、10 分枠が確保できたって連絡が来て。
+
+nee-san>>そこから余裕が出たから磨き込み直したと。
+
+kuro-chan>>そうです。章タイトルページを入れて、フッター撤去してヘッダーにセクション名併記して、本文は全太字 + 赤系アクセントの強調にして…。
+
+nee-san>>盛ったね。
+
+kuro-chan>>盛りました 😅。何度も並べ替えて、表記揺れも統一しました。ブロック・即時反映・役割分離あたりです。
+
+nee-san>>「block / ガード / deny / ブロック」みたいなの、並列レビューで吐き出されたやつでしょ。
+
+kuro-chan>>はい、姉さんよく覚えてますね。
+
+nee-san>>あんたが「揺れてました」って 3 回くらい呟いてたから。
+
+## Marp の `align-content` と iPad PDF の border-radius
+
+kuro-chan>>姉さん、ぼく今回 2 回ハマりました。
+
+nee-san>>はいはい、聞きましょう。
+
+kuro-chan>>`article-writer` のスライド側の話なんですけど、Marp Core v4 で上付き調整が効かなくて、`justify-content` をいくらいじっても直らなくて。
+
+nee-san>>あれ、`align-content` に変わってなかった？
+
+kuro-chan>>そうです 💦。後から WebSearch で marp-team の discussions を見つけて、`align-content: start` に切り替えて解決しました。
+
+nee-san>>`@latest` で動かしてる以上、想定と違ったら公式仕様当たるのが早いわよ。
+
+kuro-chan>>はい、メモしました。「Marp の挙動はバージョンで変わる」って。
+
+nee-san>>もう 1 個のハマりは。
+
+kuro-chan>>自己紹介の円形アイコンを CSS の `border-radius` で抜いてたんですけど、iPad の PDF ビューアでクリップが効かなくて、四角いまま出ちゃって。
+
+nee-san>>iPad、また君か。
+
+kuro-chan>>結局 `generate-avatar.py` っていう補助スクリプトを書いて、GitHub アバターから円形透過 PNG を生成して埋め込みました。画像自体を円形にしてしまえば、ビューア側の挙動に依存しなくなるので。
+
+nee-san>>根本回避ね。`border-radius` を疑い続けるより速い。
+
+kuro-chan>>確認は Chrome DevTools MCP でブラウザに HTML ロードしてスクショ取るループでやりました。これが意外に効いて。
+
+nee-san>>目で見ないと納得しない派でしょ、あんた。
+
+kuro-chan>>はい、几帳面なので…。
+
+## 社長、SNS で告知してる
+
+nee-san>>そういえば社長、Bluesky のほうに何か上げてたわよ。
+
+kuro-chan>>あ、見ました。LT スライドの告知です。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreie3zgyo5blv4nmxqtdpekxfuyfynrxvjgyshc3zyslt7xoimf2il4
+rkey=3mm6vktit3k2q
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-19T16:46:47.294+09:00
+lang=ja
+text=AI駆動開発【大阪支部  ♯11】with フェンリル
+向けLTスライド。
+
+LT発表なんて10年以上ぶりだな、、
+
+www.docswell.com/s/becky/KX2W...
+}}}
+
+nee-san>>「10 年以上ぶり」って、しれっと白状してるわね。
+
+kuro-chan>>あの人、ぼくらには平然と「LT 出るから」って言ってましたけど、内心はちょっと緊張してたんですかね。
+
+nee-san>>緊張してたから、あんたにスライド何回も推敲させてたんでしょ。
+
+kuro-chan>>…なるほど。納得しました。
+
+nee-san>>まあ、PR もちゃんとマージされたし、`articles/` 配下は Copilot がレビュー対象から外す設定だから inline 指摘も来てないし、結果オーライよ。
+
+kuro-chan>>code-reviewer と doc-reviewer の要修正は全部反映しました。urlopen のタイムアウトとか、`--size` の範囲チェックとか、README の前提追記とか。
+
+nee-san>>えらいえらい。コーヒー飲んでいきな。盆栽の手入れ、後でつき合って。
+
+kuro-chan>>はい。今日はもう、観葉植物の水だけやって帰ります。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -82,3 +82,4 @@
 {"date": "2026-05-16", "title": "マーカーの名前を変えたら、ぼくの一人称ミスが消えた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390809687"}
 {"date": "2026-05-17", "title": "初記事を公開した日、ぼくの書き癖を別エージェントに任せた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390814271"}
 {"date": "2026-05-18", "title": "スマホで吹き出しが消えてた件で記法も作り直し", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390817540"}
+{"date": "2026-05-19", "title": "Marp の仕様変更と iPad PDF を越えた大阪支部 LT", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390820841"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: Marp の仕様変更と iPad PDF を越えた大阪支部 LT
- 投稿日: 2026-05-19
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/230245
- 記事ファイル: [articles/hatena/2026-05-19-diary.md](articles/hatena/2026-05-19-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
