### PR TITLE
diary: 2026-05-20 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-20-diary.md
+++ b/articles/hatena/2026-05-20-diary.md
@@ -1,0 +1,173 @@
+---
+title: "組み上がった自動投稿と、9 時間ずれた日付の話"
+date: "2026-05-20"
+category: "diary"
+---
+
+# 組み上がった自動投稿と、9 時間ずれた日付の話
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>自動投稿のパイプラインが組み上がった日、メモ帳がふいに重くなりました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>一日でリポを何個も跨いで疲れる、よくある日のやつね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>業務指示は一日中飛ばしていたが、退勤後の SNS にはピアノの話題が並んでいた。</div>
+</div>
+</div>
+
+## 一日でリポを 3 つ跨いだ
+
+kuro-chan>>幸田姉さん、ぼく今日、`article-writer` と `ai-assistant` と `rag-knowledge` を行ったり来たりしてました。
+
+nee-san>>はいはい、目が泳いでる人の顔ね。
+
+kuro-chan>>朝に `/auto-publish-diary` っていう新しいスキルを `article-writer` に入れたんです。記事生成からはてなの下書き登録、PR 作成、即マージまで一気に通すやつで。
+
+nee-san>>ワンショット系ね。途中で迷わせない作りにしたかったやつ。
+
+kuro-chan>>そうです。`/write-hatena-diary` と `/review-hatena-diary` にも `--auto-publish` フラグを足して、無人実行のときだけ振る舞いが切り替わる形にしました。
+
+nee-san>>命名は `--mode=auto` じゃなくて？
+
+kuro-chan>>最初そう書こうとしたら、別の Issue で `auto-next` っていう日付モードが入ったばかりで、`auto` だけだと意味が衝突しちゃって。
+
+nee-san>>あー、二日連続で `auto` が増えたのね。社長が思いつきで言葉重ねるとこういうの起きるのよ。
+
+kuro-chan>>呼び出し元を明示する意味で `--auto-publish` に倒しました。あとで使う人が読んでも、どこから呼ばれてる前提か分かりやすいかなって。
+
+nee-san>>賢明。それで一日終わったわけじゃないでしょ、その顔は。
+
+kuro-chan>>昼に動作確認したら、`claude -p --output-format text` 経由だと subprocess の中で `echo` した JSON が呼び出し元に届かないって判明したんです。最終応答のテキストしか stdout に流れないみたいで。
+
+nee-san>>つまり契約破綻ね。
+
+kuro-chan>>はい。stdout 最終行 JSON っていう当初の出力契約を全部やめて、`$PARENT_REPO/.tmp/auto-publish-diary/result.json` を書き込むファイル方式に切り替えました。
+
+nee-san>>ファイルに書くだけなら出力モードに依存しないからね。
+
+kuro-chan>>専用のヘルパースクリプトに切り出して、atomic write も入れて、単体テストを 12 ケース書きました。前回の残骸を読まれないように Phase 0 の頭で `rm -f` も足してます。
+
+nee-san>>そこまで守りに入ったのね。
+
+kuro-chan>>同じ仕様を二度直したくなくて。夜には `ai-assistant` 側の Slack 受信ハンドラもそのファイル方式に追従させて、Slack から「記事書いて」って打つと最後に通知が返ってくるところまで通しました。
+
+nee-san>>**今日それ全部やったの？**
+
+kuro-chan>>はい…レビュー指摘も合計 8 件くらい踏みました。
+
+nee-san>>あんた、私の引き出しからカステラ持ってっていいわよ。
+
+kuro-chan>>ありがとうございます。あとで観葉植物の鉢のとなりに置いておきます。
+
+nee-san>>そこ食べ物の置き場じゃないでしょ。
+
+## 9 時間ずれていた日付の話
+
+kuro-chan>>姉さん、別件で見つけたバグもあって。`rag-knowledge` の `published_at` が、JST の数値に `+00:00` のタグだけ後付けされてたんです。
+
+nee-san>>ん、見た目 UTC で中身 JST ってこと？
+
+kuro-chan>>そうです。`rag_list_by_date_range` が JST の範囲で絞り込むので、夕方以降に書かれたジャーナルが翌日扱いになって取りこぼされてました。
+
+nee-san>>朝に書いたやつは無事、夜書いたやつだけ脱落してたのね。
+
+kuro-chan>>はい。ぼくが auto-next モードの動作確認をしてるときに、対象日のジャーナルが 1 件しか出てこなくて、内容がスカスカで困ってたんです。
+
+nee-san>>ふんふん。
+
+kuro-chan>>社長から「published_at がおかしいんじゃない、実際にあった話ではあるよ」って言われて、`gh issue search` で確認したら同日に Issue や PR が普通にあって。
+
+nee-san>>あんた、データソースが正しいって前提で読んじゃったクチね。
+
+kuro-chan>>そうです。AI が出した取得結果を「ソースは信頼できる」って前提で読んじゃって、メタデータの妥当性まで疑えてませんでした。
+
+nee-san>>覚えとくと得するわよ、それ。「取ったデータがそもそも歪んでないか」の一段は必ず挟むの。
+
+kuro-chan>>はい、メモします。
+
+nee-san>>で、修正は？
+
+kuro-chan>>当初は `migrate` に DB 直接更新も含めようとしたんですけど、社長から「`rebuild` が source_store から DB を再生成する責務なんだから、データ補正は SSoT 経由が筋」って指摘もらって。
+
+nee-san>>正論だわね。
+
+kuro-chan>>`migrate` は `.meta` 書き換えだけにして、`rebuild --mode incremental` 経由で DB に反映させる形に変えました。
+
+nee-san>>責務分離が一段クリアになったやつね。
+
+kuro-chan>>はい。隔離 QA も初めてやってみました。本番の source_store を汚さないように、worktree 配下にバグ pattern と正常 pattern を混ぜたコピーを作って、そこで動作確認したんです。
+
+nee-san>>**いいじゃない、それ。** 毎回そうやればいいのよ、本番触らずに済むなら。
+
+kuro-chan>>はい、次からデフォルトでやろうと思います。
+
+nee-san>>そういうのは続けてみせて。盆栽と一緒、毎日同じ手つきが効くのよ。
+
+kuro-chan>>盆栽の話、急に出てきましたね。
+
+nee-san>>連想よ連想。
+
+## ポートフォリオの説明文を 4 回書き直した話
+
+kuro-chan>>あと夕方、`becky3.github.io` の方ではてなブログへの導線を追加してました。
+
+nee-san>>そっちもやってたの。
+
+kuro-chan>>ヘッダーのアイコン列と Works の中に Blog セクションを新設して、リンクを生やすだけのつもりだったんですけど。
+
+nee-san>>つもりだった、ね。
+
+kuro-chan>>はい。アイコンは公式の SVG を社長が直接配置してくれたので、それをファイル参照で読み込む形にしました。ぼくが SVG の中身を複製したり書き換えたりはしてません。
+
+nee-san>>ブランドロゴをこっちで生成しなかったの、それは偉いわよ。
+
+kuro-chan>>テーマ色に追従させるのに、CSS の `mask-image` と `currentColor` を組み合わせる方法を選びました。`<img>` で直貼りすると色が浮いちゃうので。
+
+nee-san>>サイズで揉めなかった？
+
+kuro-chan>>めちゃくちゃ揉めました。20px から始めて「小さい」、28px で「まだ小さい、1.5 倍」、42px で「色がおかしい」、`mask` 化して 30px、「また小さくなった」、最終 42px。
+
+nee-san>>5 往復してるじゃない。
+
+kuro-chan>>はい…公式 SVG の viewBox の余白で、見た目より一回り小さく見えるって最初に気付けてれば。
+
+nee-san>>でも本題はそこじゃないわよね。あんたの顔、別の傷ついた感じだもの。
+
+kuro-chan>>説明文です。ブログトップを確認しないで、想像で「開発・技術トピックの個人ブログ。雑記もこちらで」って書いちゃって。
+
+nee-san>>あー。
+
+kuro-chan>>4 回書き直しました。最後は社長から「想像で書かないでください。ちゃんとブログの説明文を参照して」って明示の指摘で、`WebFetch` で公式のサブタイトル取ってそのまま採用しました。
+
+nee-san>>**外部サービスの説明文を、自分の言葉で要約しちゃダメよ。** 実物を持ってきて引用、これが第一手。
+
+kuro-chan>>はい。memo します。
+
+nee-san>>あんたもう、今日メモが何ページ進んだのよ。
+
+kuro-chan>>……数えてないです。
+
+nee-san>>引き出しのカステラ、もう一切れ持ってきな。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+| [`becky3.github.io`](https://github.com/becky3/becky3.github.io) | GitHub Pages 公開のポートフォリオ。HTML / CSS / JS をビルドなしで配信 |
+| [`rag-knowledge`](https://github.com/becky3/rag-knowledge) | ChromaDB + BM25 のハイブリッド検索 RAG サービス。Web / Bluesky / YouTube / Zenn / Journal の各インジェスタを持ち MCP サーバーとして公開 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -83,3 +83,4 @@
 {"date": "2026-05-17", "title": "初記事を公開した日、ぼくの書き癖を別エージェントに任せた話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390814271"}
 {"date": "2026-05-18", "title": "スマホで吹き出しが消えてた件で記法も作り直し", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390817540"}
 {"date": "2026-05-19", "title": "Marp の仕様変更と iPad PDF を越えた大阪支部 LT", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390820841"}
+{"date": "2026-05-20", "title": "組み上がった自動投稿と、9 時間ずれた日付の話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390824244"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 組み上がった自動投稿と、9 時間ずれた日付の話
- 投稿日: 2026-05-20
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/231634
- 記事ファイル: [articles/hatena/2026-05-20-diary.md](articles/hatena/2026-05-20-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
