### PR TITLE
diary: 2026-05-21 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-21-diary.md
+++ b/articles/hatena/2026-05-21-diary.md
@@ -1,0 +1,148 @@
+---
+title: "二時間ハングを止めて、記事のボケツッコミも取り戻した日"
+date: "2026-05-21"
+category: "diary"
+---
+
+# 二時間ハングを止めて、記事のボケツッコミも取り戻した日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>二時間ハングの正体、ぼくの書いたスクリプトでした…</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。達観して見える相棒タイプ。<br>タイムアウト入れたら、寝てる間に勝手に進むようになったわね</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で「自動投稿が回りだした」と勝ち誇っている</div>
+</div>
+</div>
+
+## 二時間ハングの容疑者はぼくでした
+
+kuro-chan>>幸田姉さん、まず昨日のおさらいなんですが。
+kuro-chan>>`/auto-publish-diary` を無人で回したら、`git push` で二時間ぐらい止まったままになってまして。
+nee-san>>覚えてる。Hatena に下書きだけ刺さって、ブランチは宙ぶらりんって状態ね。
+kuro-chan>>はい。それで Issue を立てて、PR で外部 IO 全部に `timeout 120` を被せました。
+nee-san>>ほー。`git pull` も `gh pr create` も `gh pr merge` も全部？
+kuro-chan>>はい。一個だけ縛っても結局どこかが詰まる気がして、全部に被せたんです。
+nee-san>>あんたらしいやり方ね。1 個ずつ確かめるより先に全部 raincoat を着せたわけだ。
+kuro-chan>>そうです、雨の中で傘どこだっけって探したくないので。
+
+kuro-chan>>あと、SSH の方は `BatchMode=yes` と `ConnectTimeout=30` も足してます。
+nee-san>>credential helper の対話で止まるやつ封じね。よくやった。
+kuro-chan>>はい、もう昨日の二時間ハングは出ないはず…でした。
+
+nee-san>>でした？
+kuro-chan>>Copilot のレビューで `if ! cmd; then EXIT=$?` のところを指摘されまして。
+kuro-chan>>「`!` で反転した後の `$?` を取ってるから、常に 0 が入りますよね」って。
+nee-san>>えっ。それタイムアウト識別したかった本丸でしょ。
+kuro-chan>>本丸でした。ぼくも書いてる時に「これで実コードが 124 出してくれる」って信じきってまして。
+nee-san>>信じる前に試そうね。
+kuro-chan>>はい…。`bash -c 'if ! false; then echo $?'` で本当に 0 が出てくるの見て頭抱えました。
+nee-san>>頭抱えるところまでは普通の感想だけど、その後ちゃんと `EXIT=0; cmd || EXIT=$?` のパターンに直したんでしょ？
+kuro-chan>>4 箇所全部置換しました。`timeout 1 sh -c "exit 124" || E=$?` で `E=124` が拾えるところまで実機で確認してから push しました。
+nee-san>>偉い。**指摘ありがとうで脊髄反射で直さず、根拠取りに行くやつ**は応援するよ。
+
+kuro-chan>>あと doc-reviewer は `set -o pipefail` の宣言を見落として「pipefail 前提が明示されてない」と誤指摘してきたんですが、`if !` の `$?` バグは検出できなかったんですよね。
+nee-san>>はは、住み分けね。Copilot が bash の罠係、doc-reviewer が文書構造係。
+kuro-chan>>はい。**両方走らせた方がいい**ってことが今回ハッキリしました。
+
+## 記事の役割分担を組み直して、ついでに 3 並列で検証した
+
+kuro-chan>>姉さん、もう一個あって。
+kuro-chan>>はてな記事のクオリティが、ぼく主導じゃなくて姉さん主導になってる時期があったの覚えてますか。
+nee-san>>覚えてる。**「コーヒー要る？」「いただきます」**って毎回ぼけーっと締めるやつ。
+kuro-chan>>あれです。Issue と PR で、進行パターンを 6 枠（A〜F）にしてサイコロで選ぶ仕組みに直しました。
+nee-san>>サイコロ？
+kuro-chan>>はい。クロ作業実況、姉さん振り、同時遭遇、メタ会話、役割逆転、自由形式。決定的にフィットするのが無ければ `python -c "import random; print(random.choice(list('ABCDEF')))"` で機械的に決めます。
+nee-san>>逃げ場の用意の仕方が真面目すぎる。
+
+kuro-chan>>面白味の要素も明文化しました。リアクション主導、落差・ギャップ、緊張と緩和、天丼、長短コントラスト、意味のない台詞を削る、メタ・Callback。
+nee-san>>**天丼は 3 回目でスケール変えろ**ってやつね。同じネタを 3 回素のまま打つの禁止。
+kuro-chan>>はい。3 回目で対象や規模を変える縛りだけ入れました。
+
+kuro-chan>>あと、姉さんとぼくにキャラ追加特性を 3 つずつ足しました。
+nee-san>>聞こうか。
+kuro-chan>>ぼくは「実はゲーマー」「観葉植物を 5 鉢以上育てている」「キーボード配置を 1mm 単位で揃え直す」。
+nee-san>>反射神経が異常に良いゲーマーで観葉植物 5 鉢って、線が細いんだか太いんだか分からない子ね。
+kuro-chan>>姉さんは「スポーツ大得意」「盆栽を丁寧に育てている」「引き出しの中が用途別に区分整理されている」です。
+nee-san>>盆栽はいいけど、引き出し区分は職場でやってバレるとちょっと恥ずかしいから黙ってて。
+kuro-chan>>はい。
+
+kuro-chan>>検証は agent を 3 並列で起動して、2/10・2/14・2/15 の 3 日分を再生成しました。
+nee-san>>並列で経緯渡さずに走らせたわけ？
+kuro-chan>>はい。ガイドライン本体だけで Claude が同じ品質を出せるかの試験です。結果、進行パターン D と A が採用されて、冒頭の挨拶定型句もちゃんと避けられました。
+nee-san>>「幸田姉さん、聞いてください」が初出フル表記で揃ったのね。
+kuro-chan>>3 記事全部でそうなりました。ガイドラインの効きはちゃんと出てます。
+
+nee-san>>で、社長その辺の事情、知ってるんだっけ？
+kuro-chan>>たぶん知らないと思います。SNS は勝ち誇ってましたけど。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidkheitw7hy2gktgodf5bacv2wbhw6nm2hqmoefjlom5uy72zdk6i
+rkey=3mmdux2vl2s2h
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-21T16:19:02.656+09:00
+text=開発日誌をベースにした日記自動作成がようやく回りだした。
+これで、毎日作業するだけで無限にコンテンツ増やせる。
+
+beckyjpn.hatenablog.com/archive/2026...
+}}}
+
+nee-san>>「ようやく回りだした」って、回した方の苦労はリンク先に書いてないんでしょ。
+kuro-chan>>書かれてないですね。ぼくらが timeout 入れ直して、ガイドライン書き直して、3 並列で検証した話は出てこないです。
+nee-san>>「毎日作業するだけで無限にコンテンツ」って、その毎日の作業してるの私らだからね。
+kuro-chan>>はい…。
+nee-san>>まあ、勝ち誇らせとくのが平和ってやつね。
+
+## 連続実行で芋づる式に出た落とし穴
+
+kuro-chan>>姉さん、最後にもう一個。今日のハング撲滅って、元はと言えば `ai-assistant` 側の連続実行検証から芋づるで出てきたんですよ。
+nee-san>>10 日分連続で走らせたやつね。
+kuro-chan>>はい。初回失敗で即停止のはずだったんですが、いろんなものが順番に表面化しまして。
+nee-san>>例えば？
+kuro-chan>>まず、`claude -p --output-format text` がログ 0 バイトのまま 80 分動いてたのを「止まった」と判定して停止させちゃったんです。
+nee-san>>動いてた？
+kuro-chan>>はい、後で PR が 23:07 にマージされてるのを見つけて、最終応答生成の遅延だっただけと判明しました。
+nee-san>>**ログ無音 = 停止じゃない**って今日の教訓ね。worktree と commit history を進捗指標に併用しないとダメ。
+kuro-chan>>はい。
+
+kuro-chan>>あと、Git Bash で `taskkill /F /T /PID <pid>` を打ったら `/F` が `F:/` に変換されてエラーになりまして。
+nee-san>>MSYS の自動パス変換ね。
+kuro-chan>>そうです。PowerShell から打ち直したら通りました。
+nee-san>>Windows ネイティブの `/オプション` 形式のコマンドは PowerShell 側でやるのが事故が少ない、と。
+kuro-chan>>はい、メモしました。
+
+kuro-chan>>あと、もう 1 件の Issue は社長と相談して「コード変更なしで Issue クローズ」になりました。
+nee-san>>へえ、珍しいパターン。
+kuro-chan>>上位の `article_publish_timeout` は config で 1200 秒（20 分）あって、下位 IO は 120 秒で必ず終わるので、LLM 生成時間（実測 13 分くらい）を吸収できる余裕は残ってる、と。
+nee-san>>**「Issue を起こした以上は何か変更しないと」ってバイアス**に倒れずに済んだのね。
+kuro-chan>>はい。Issue 本文には「現状 60 分 timeout」って書いてあったんですが、実態は 20 分でして、計画段階で SSoT と突き合わせたら判断軸が変わりました。
+nee-san>>Issue 本文の数値は古い前提のことがあるって話ね。
+
+kuro-chan>>今日はそんな感じで、ハング撲滅と記事の役割分担再構築と Issue クローズ判断と、3 つ並行で片付きました。
+nee-san>>**1 セッションが長くなったぶん、信頼性は上がってる**ってあの人も書いてたわよ。
+kuro-chan>>あ、見てたんですか。
+nee-san>>覗いただけ。
+
+## プロジェクトの説明
+
+話に関連するプロジェクト一覧です。
+
+| リポジトリ名 | 説明 |
+|---|---|
+| `agent-commons` | `~/.claude/` 配下に配置する全プロジェクト共通の Claude Code 設定（ルール・スキル・エージェント・Hooks・仕様書テンプレート） |
+| [`ai-assistant`](https://github.com/becky3/ai-assistant) | Slack 上で動作する AI 学習支援ボット。RSS 要約配信・チャット応答・Remote Control 起動などを担う |
+| [`article-writer`](https://github.com/becky3/article-writer) | 開発ジャーナル・仕様書・Issue を素材に Zenn / はてな等の技術記事や日記を生成する Claude Code スキル群 |
+
+リンクがないものは private リポジトリです。
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -84,3 +84,4 @@
 {"date": "2026-05-18", "title": "スマホで吹き出しが消えてた件で記法も作り直し", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390817540"}
 {"date": "2026-05-19", "title": "Marp の仕様変更と iPad PDF を越えた大阪支部 LT", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390820841"}
 {"date": "2026-05-20", "title": "組み上がった自動投稿と、9 時間ずれた日付の話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390824244"}
+{"date": "2026-05-21", "title": "二時間ハングを止めて、記事のボケツッコミも取り戻した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/17179246901390827672"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 二時間ハングを止めて、記事のボケツッコミも取り戻した日
- 投稿日: 2026-05-21
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/22/233141
- 記事ファイル: [articles/hatena/2026-05-21-diary.md](articles/hatena/2026-05-21-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
