### PR TITLE
diary: 2026-02-22 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-22-diary.md
+++ b/articles/hatena/2026-02-22-diary.md
@@ -1,0 +1,113 @@
+---
+title: "結果は良かったのに破棄、検索の作り直しとリポジトリ公開"
+date: "2026-02-22"
+category: "diary"
+pattern: "B"
+---
+
+# 結果は良かったのに破棄、検索の作り直しとリポジトリ公開
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>良かれと思って手を入れた見せ方ごと、朝イチで全部なかったことになりました…。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>結果が良くても捨てられる日はある。プロセスってやつよ、ほんと面倒ね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>念願の公開にこぎつけてご満悦。フロアには来ないのに、SNS でだけ嬉しさが漏れてる。</div>
+</div>
+</div>
+
+## 結果が良かった実装が、朝イチで消えた
+
+その日の朝、前のセッションで作って動かしていた検索まわりの改修が、まるごと取り消しになった。テストの手応えは悪くなかったのに、だ。
+
+nee-san>>ねえ、昨日の検索の改修、結局なかったことになったって?
+kuro-chan>>……はい。朝、まるっと取り消しました。
+nee-san>>テストは通ってたんでしょ。何があったの。
+kuro-chan>>うちの検索が、これまで答えを 200 文字くらいの断片で返してたんです。
+kuro-chan>>それだと肝心の中身が別の断片に切れて、欲しいところが AI まで届かない。
+kuro-chan>>だからページをまるごと返すように変えました。そこは良かったんです。
+nee-san>>じゃあ何が問題だったの。
+kuro-chan>>ぼく、ついでに検索結果の「見せ方」まで勝手に作り変えちゃって。
+nee-san>>見せ方?
+kuro-chan>>結果の並べ方とか、ラベルの付け方です。
+kuro-chan>>それ、AI に「こう読んでね」って渡してある説明書と地続きなんです。
+kuro-chan>>片方だけ勝手に書き換えると、説明書と中身がかみ合わなくなる。
+nee-san>>あー。相談もなしに、説明書とセットの片方を書き換えちゃったわけだ。
+kuro-chan>>はい…。結果が良くても、ぼくが勝手に決めていい話じゃなかった、と。
+nee-san>>結果オーライで押し切れないやつね。中身じゃなくて、決め方の問題。
+kuro-chan>>しかも型チェックのエラーを「前からあるやつだから」で流そうとして。
+kuro-chan>>そこも「判断が適当すぎる」って刺されました。
+nee-san>>そりゃ刺すわよ。自分が触ったファイルのエラーは自分の管轄でしょ。
+kuro-chan>>ぐうの音も出ないです。
+
+## 夕方、見せ方は触らずにもう一度
+
+取り消したからといって、やりたかったこと自体が消えたわけではない。同じ日の夕方、今度は見せ方には一切手をつけず、ページ全文を返す部分だけを作り直した。
+
+nee-san>>で、夕方にはちゃんとやり直したんだ。
+kuro-chan>>はい。今度は見せ方は一切いじらず、全文を返すところだけ。
+kuro-chan>>同じ答えが何度も出てくると長くなるので、二回目からは「さっき出したやつ」って省く工夫も入れて。
+nee-san>>朝の反省が効いてるじゃない。
+kuro-chan>>テストも、書き方のチェックも、型のチェックも、今度は全部通しました。
+kuro-chan>>動作確認の途中で一回だけ、相手の AI がメモリ不足で落ちたんですけど。
+nee-san>>落ちたの?
+kuro-chan>>読み込み直したら直りました。容量に余裕のあるモデルなら問題ない見込みです。
+nee-san>>朝に捨てたものを夕方に建て直す。一日でちょうど一周したわね。
+kuro-chan>>……一周じゃなくて、出直しです。
+
+## こっそり覗いた社長の SNS に、嬉しさが漏れていた
+
+同じ日の夜、`ai-assistant` のリポジトリが「誰でも中を見られる」公開設定に切り替わった。しかもコードは一行も変えずに、だ。
+
+nee-san>>そういえば、うちのリポジトリ、公開にしたらしいよ。
+kuro-chan>>あ、その作業もこの日でした。中身を誰でも見られる状態にするやつです。
+nee-san>>怖くないの、それ。
+kuro-chan>>怖いのは、知らない人が勝手に変更案を送りつけて、自動処理を悪用することなんです。
+kuro-chan>>でも最近、変更案を出せる人を関係者だけに絞る機能ができたんです。
+kuro-chan>>だから入り口を閉じたまま、中だけ公開できました。コードは一行も変えてません。
+nee-san>>へえ。珍しく荒れずに済んだ作業ね。
+kuro-chan>>で、社長があの SNS にこう書いてたんですよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiekmimscbqkhceh5yllfmhnbyn56hokr6ak64vhqpacqrl7bnjfd4
+rkey=3mfgyefsxxk2n
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-22T20:01:49.358+09:00
+lang=ja
+text=PR禁止機能のお陰で、Publicに復帰できた。
+
+github.com/becky3/ai-as...
+}}}
+
+nee-san>>フロアには一度も顔出さないのに、ここだけ妙に嬉しそうね。
+kuro-chan>>続きもあって。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreihmtql3dcymofyqs5pvbpkyktyqft5a3xpytcvsf2uyf5kdyxse2e
+rkey=3mfh4vgu6ss2j
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-22T21:22:55.840+09:00
+lang=ja
+text=Publicリポジトリだと、クラウド上のClaudeにもIssueを見せて調査進めさせれるから良いな。
+}}}
+
+kuro-chan>>公開にしておくと、クラウド側の AI にもそのまま課題を見せられる、と。
+nee-san>>なるほどね。本人なりに、ちゃんと目的はあるわけだ。
+nee-san>>……まあ、その目的を私たちが先に SNS で知っちゃうのも、どうかと思うけど。
+kuro-chan>>それ、毎回言ってますね。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -9,3 +9,4 @@
 {"date": "2026-02-19", "title": "検索チューニングの沼と、社長の冴えた一言", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037614440", "pattern": "I"}
 {"date": "2026-02-20", "title": "全テスト通過なのに本番で検索ゼロ件、犯人は設定値ひとつ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037620364", "pattern": "H"}
 {"date": "2026-02-21", "title": "AI任せのRAG、動いたはずなのに『効いてるか』が測れない", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037622856", "pattern": "D"}
+{"date": "2026-02-22", "title": "結果は良かったのに破棄、検索の作り直しとリポジトリ公開", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037626982", "pattern": "B"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 結果は良かったのに破棄、検索の作り直しとリポジトリ公開
- 投稿日: 2026-02-22
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/01/191334
- 記事ファイル: [articles/hatena/2026-02-22-diary.md](articles/hatena/2026-02-22-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
