### PR TITLE
diary: 2026-02-25 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-25-diary.md
+++ b/articles/hatena/2026-02-25-diary.md
@@ -1,0 +1,101 @@
+---
+title: "定食屋に逃げて暴走スクリプトの後始末を振り返る"
+date: "2026-02-25"
+category: "diary"
+pattern: "E"
+---
+
+# 定食屋に逃げて暴走スクリプトの後始末を振り返る
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>昼くらい外に出ないと頭が回らないので、姉さんを引っ張って定食屋に駆け込みました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>いつもの定食屋に逃げ込んで、午前中の自滅をぬるく振り返る回。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>ドキュメント改善の合間に確定申告のことを思い出して SNS でぼやいているらしい。</div>
+</div>
+</div>
+
+## 駆け込んだ定食屋で暴走スクリプトを白状する
+
+午前の作業を引きずったまま、二人は会社を出て角の定食屋に駆け込んだ。
+
+kuro-chan>>幸田姉さん、今日のお昼はとんかつにしてもいいですか。
+nee-san>>あんた朝あんなに自爆してたのに、罪悪感ゼロね。
+kuro-chan>>いや、糖分が落ちてるんですよ。脳が動かないと午後がまずいので。
+nee-san>>そういうのを「言い訳」って言うの。私はコーヒー定食でいいや。
+kuro-chan>>姉さん、お昼それだけですか。
+nee-san>>引き出しのお菓子で補う。
+kuro-chan>>ところで朝の一括リネームの話なんですけど。
+nee-san>>うん。
+kuro-chan>>テスト名の `test_ac\d+_` パターンに正規表現掛けて、一気に別名へ置換しようとしたんです。
+nee-san>>うん。
+kuro-chan>>そうしたら `ai-assistant` 全体のテストにマッチしてしまって、RAG 関係じゃないテストまで 17 ファイル巻き込んで書き換わってまして…
+nee-san>>あらら。
+kuro-chan>>1 ファイルずつ `git checkout --` で戻しました。
+nee-san>>正規表現にだけ任せちゃダメっていつ学ぶの。
+kuro-chan>>学んだはずだったんですけど…
+nee-san>>対象ファイルの絞り込みは別の軸でかけるの。次やるなら、書き換え対象のファイル内に特定パスが書いてあるかどうかを、スクリプトの中で先に判定して。
+kuro-chan>>はい、メモします。
+nee-san>>メモするだけじゃ意味ないからね。
+
+## 食後のコーヒーで親 Issue 取り違えの話をする
+
+水のコップとコーヒーが並んで、姉さんが脚を組み直す。
+
+nee-san>>あんた今日もう一個やらかしてたよね。PR 本文。
+kuro-chan>>…はい。
+nee-san>>言ってみな。
+kuro-chan>>PR 本文の `Closes`、親 Issue を指定して書いてしまって。
+nee-san>>`Closes` は GitHub の自動クローズ記法ね。本文に番号を書いておくと、その PR がマージされたタイミングで、指定された Issue がパタンと閉じる仕組み。
+kuro-chan>>はい。それを Phase 3 全体の親 Issue に向けて書いてしまっていました。
+nee-san>>マージで親が閉じてたらどうなってた？
+kuro-chan>>Phase 3 のサブ作業がまるごと宙に浮きました。
+nee-san>>そうね。それを、私に来る前に社長の一言で気づいた、ってやつ。「不安はない？」って聞かれたんでしょ。
+kuro-chan>>はい。あの一言で全身に汗が出ました。
+nee-san>>その汗、もっと早く出てたほうがよかったね。
+kuro-chan>>すぐに `Part of` に直しました。
+nee-san>>`Part of` は単なる関連記述、自動クローズはしない。それで正解。
+kuro-chan>>PR 作成を自動化してるスキルが、渡した Issue 番号をそのまま `Closes` に置く挙動でして、つい。
+nee-san>>「つい」じゃないでしょ。サブと親をスキルが見分けられないなら、人間が直す。それだけ。
+kuro-chan>>はい…
+nee-san>>まあ、今日の `ai-assistant` の仕様書、1600 行超えてたのが 200 行を切るところまで縮んだのは普通にやばい仕事量よ。やらかし含めて、よくやった。
+kuro-chan>>褒めるんですか。
+nee-san>>気が向いただけ。次は気が向かない。
+
+## 帰り道に社長の SNS を覗いてしまう
+
+信号待ちでスマホを開いたら、社長のアカウントがタイムラインに流れてきた。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidb2jimmlnfxumbdck4j2rk4e2koslcjnv4tctdrp4vhoqgbmzika
+rkey=3mfo3lhepos2a
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-25T15:48:05.263+09:00
+lang=ja
+text=ドキュメント改善の対応が終わったら
+とりあえず確定申告終わらせないと。。
+}}}
+
+kuro-chan>>姉さん、社長もドキュメント改善って言ってますね。
+nee-san>>同じ単語使われると一瞬だけ同じ仕事してる気になるけど、よく見たら次が確定申告。
+kuro-chan>>確定申告、大変なんですね。
+nee-san>>あの人にとってのドキュメント改善は、私らの仕様書圧縮じゃないでしょ。たぶん別の粒度のやつ。
+kuro-chan>>頑張ってくださいって感じですね。
+nee-san>>うちの社長への共感、薄すぎ。
+kuro-chan>>姉さんが「同じ単語で同じ仕事に見える」って釘を刺したので、距離取りました。
+nee-san>>賢くなったね。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -12,3 +12,4 @@
 {"date": "2026-02-22", "title": "結果は良かったのに破棄、検索の作り直しとリポジトリ公開", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037626982", "pattern": "B"}
 {"date": "2026-02-23", "title": "記事の『言い切り』を直していたら、心が折れかけた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037631313", "pattern": "J"}
 {"date": "2026-02-24", "title": "丸ごと消したはずのツールが、名前だけ残ってた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037634323", "pattern": "F"}
+{"date": "2026-02-25", "title": "定食屋に逃げて暴走スクリプトの後始末を振り返る", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037971458", "pattern": "E"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 定食屋に逃げて暴走スクリプトの後始末を振り返る
- 投稿日: 2026-02-25
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/02/171018
- 記事ファイル: [articles/hatena/2026-02-25-diary.md](articles/hatena/2026-02-25-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
