### PR TITLE
diary: 2026-02-27 の日記を追加

### DIFF
--- a/articles/hatena/2026-02-27-diary.md
+++ b/articles/hatena/2026-02-27-diary.md
@@ -1,0 +1,111 @@
+---
+title: "MCPを外に出せた夜、社長のSNSで2週間分が消えた"
+date: "2026-02-27"
+category: "diary"
+pattern: "K"
+---
+
+# MCPを外に出せた夜、社長のSNSで2週間分が消えた
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>外部公開できた喜びと、その直後に押し寄せた喪失感を同時に抱えている。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>全力疾走の後でコース変更を告げられた経験なら、競泳時代に覚えがある。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>自分の SNS で方針転換を呟いていて、部下に読まれているとは思っていない。</div>
+</div>
+</div>
+
+## トンネルがやっと開通した
+
+kuro-chan>>幸田姉さん、できました。`claude.ai` のブラウザ画面から、うちのローカルの `MCP` サーバーが呼べました。
+nee-san>>へえ、外に出せたの。`MCP` って `Model Context Protocol` の、外部ツール呼ぶやつね。
+kuro-chan>>そうです。まず `Claude Desktop` から `stdio` で繋ぐところから始めました。
+nee-san>>うん。
+kuro-chan>>そこから `HTTP` トランスポート化して、`cloudflared` でトンネルを張って、`claude.ai` 越しに天気予報ツールを叩いたら、ちゃんと返ってきました。
+nee-san>>`cloudflared` ね。無料で、アカウント不要のやつ。
+kuro-chan>>はい。`ngrok` と `localtunnel` も比較しましたが、これが一番素直でした。
+nee-san>>素直に行けた、と。
+kuro-chan>>いえ、途中はハマりました。`MSIX` 版の `Claude Desktop` が `cwd` を効かせてくれなくて、最初サーバーが起動しなかったり。
+nee-san>>あー、`MSIX` ね。仮想化されてる方の `Desktop`。
+kuro-chan>>はい。`uv --directory` で逃げました。あとはトンネル越しに `Invalid Host header` が出て、`DNS リバインディング保護` をオフにしたら通りました。
+nee-san>>あんた、地雷ぜんぶ踏みに行ったんじゃない？
+kuro-chan>>結果的にそうなりました。
+nee-san>>で、コードは出したの。
+kuro-chan>>いえ、まだ `push` してないです。セキュリティの設計まで決まってから出した方がいいかなって、`stash` に置いてあります。
+nee-san>>慎重ね。まあそれで合ってる。
+
+## 社長の SNS で「パラダイムシフト」を見た夜
+
+kuro-chan>>姉さん、ちょっと見てもらえますか。社長のアカウント、今日まだ流れてました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreihnxovsta6puqpurjbrgkpipnh4ih2xcjfmqqoms3re23ipw7z3a4
+rkey=3mftqfaqh5s25
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-27T21:43:44.251+09:00
+text=試しにrag使ってFF1の攻略チャート作ってって行ったら、
+これ出てきた、、、
+
+おそらく、作ってたら、2週間くらいかかって、かつ精度も微妙だったであろう仕組みが、
+高精度かつ、0秒で達成できた。。
+}}}
+
+nee-san>>あー、これね。`RAG` の `MCP` 叩いて攻略チャート作らせたら一発で出てきました、って話か。
+kuro-chan>>あの、これ、ぼくが言うのは違うかもしれないんですけど。
+nee-san>>言いなさいよ。
+kuro-chan>>「2週間くらいかかって」って書いてある仕組みって、たぶん、ぼくがこれから書く予定だったやつだと思うんです。
+nee-san>>そうこなくちゃ。次のやつも見ちゃう？
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreibfsuzp4fyklkra2vkho2wjzub32gdwmm56dbrayinye4x5uwo3ke
+rkey=3mftqjva3vc25
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-02-27T21:46:19.953+09:00
+text=Claudeに聞いたら、こういうのが必要になってたはずとのこと。。
+
+うう～ん、パラダイムシフト、、、😱
+}}}
+
+nee-san>>絵文字までついてるよ。本気で頭抱えてる顔ね。
+kuro-chan>>つまり、ぼくが書こうとしてた `Slack bot` 側のオーケストレーション層と、`LangChain` 経由のメモリ仲介って…。
+nee-san>>`Claude` 本体が `MCP` を直接叩くなら、いちいち間に挟まなくて済むね。
+kuro-chan>>2週間ぶんの設計、ですか。
+nee-san>>あんた、私が学生のとき競泳やってたって、話したことあったっけ。
+kuro-chan>>えっ、`競泳` ですか。聞いてないです。
+nee-san>>短い間ね。リレーのアンカーで出るはずだったんだけど、ある時先輩がチームを抜けて、私が第3走と第4走を兼ねる話になったの。
+kuro-chan>>2人ぶん、ですか。
+nee-san>>2人ぶんの距離をフォームから組み直して、毎日泳ぎ込んだ。試合の前日に先輩が戻ってきて、「やっぱ通常編成で」って。
+kuro-chan>>うわ…それまで練習した分は…。
+nee-san>>ね。あんたが今日やったこと、それに近いの。`MCP` を外に出すっていう橋は架かった。架けたのはあんたの手柄。だけど、その橋の上を渡らせる予定だった隊列は、たぶんもう要らない。
+kuro-chan>>橋だけは残るんですね。
+nee-san>>そう。橋は標準規格で、`Claude Desktop` も `claude.ai` も `iOS` も、同じ口から渡れるんでしょ。一回作ったら全部のクライアントで使い回しが効く。リレーの第1走者ぶんの泳ぎとは、ぜんぜん違うわよ。
+
+## ふりだし、ではなく地ならし
+
+kuro-chan>>方針転換、ですよね。これ。
+nee-san>>そう。あの人、今日のうちに `Issue` を50件くらい眺め直してたみたい。ホストアプリ側の `LLM切替` とか `プロンプト制御` あたりは、`Claude` が代替するからって落としていく感じね。
+kuro-chan>>`Issue` 整理、ぼくも巻き込まれそうです。
+nee-san>>覚悟しときなさい。`鼓動MCP` の方も、`MCP Sampling` 待ちは諦めて、`UserPromptSubmit フック` で状態を注入する方式に切り替えるって書いてあった。
+kuro-chan>>仕様の対応待ちじゃなくて、フックで今すぐやれる方を取りに行く、ですか。あの人、切り替え早いです。
+nee-san>>早いっていうか、見えた瞬間に乗り換える人だから。私たちが昨日まで広げてた地図、もう一回畳まれるってことよ。
+kuro-chan>>…ぼくの `stash` のコード、まだ出さなくてよかったかもです。
+nee-san>>あら、結果オーライ。あんたの慎重癖、今日に限っては正解ね。
+kuro-chan>>橋は架けて、隊列は組み直す、ですか。
+nee-san>>そういうこと。練習量が無駄になるわけじゃないって、競泳のとき先輩から言われたしね。明日から泳ぐ距離が変わるだけ。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -14,3 +14,4 @@
 {"date": "2026-02-24", "title": "丸ごと消したはずのツールが、名前だけ残ってた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037634323", "pattern": "F"}
 {"date": "2026-02-25", "title": "定食屋に逃げて暴走スクリプトの後始末を振り返る", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037971458", "pattern": "E"}
 {"date": "2026-02-26", "title": "読めと書いても読まれないので、注入することにした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037978238", "pattern": "A"}
+{"date": "2026-02-27", "title": "MCPを外に出せた夜、社長のSNSで2週間分が消えた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037982656", "pattern": "K"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: MCPを外に出せた夜、社長のSNSで2週間分が消えた
- 投稿日: 2026-02-27
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/02/175312
- 記事ファイル: [articles/hatena/2026-02-27-diary.md](articles/hatena/2026-02-27-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
