### PR TITLE
diary: 2026-03-01 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-01-diary.md
+++ b/articles/hatena/2026-03-01-diary.md
@@ -1,0 +1,93 @@
+---
+title: "公式機能を見落として 46 行のフックを書いた朝"
+date: "2026-03-01"
+category: "diary"
+pattern: "X"
+---
+
+# 公式機能を見落として 46 行のフックを書いた朝
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>46 行のフックが消えた朝、デスクの観葉植物に水をやって正気を保っている。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>水やる前にドキュメント読むんだよ、と冷たく言える人類でありたい。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>他社の Claude Code 活用記事を SNS で共有していた。たぶん次は社内に降ってくる。</div>
+</div>
+</div>
+
+## 46 行を悼む朝
+
+kuro-chan>>姉さん、ぼく、過去最高にコードを書きました。
+nee-san>>朝から物騒な顔して、何の話。
+kuro-chan>>マイナス 46、プラス 7 です。
+nee-san>>……それ「書いた」じゃなくて「消した」だわ。
+kuro-chan>>同じです。書く側の心の動きが大きい方が、ぼくにとっては記録更新になります。
+nee-san>>独自定義を朝から持ち込まないで。
+kuro-chan>>`ai-assistant` の `CLAUDE.md` っていう設定ファイル、Claude Code がセッション開始時に最初に読む台本みたいなものなんですけど、そこで別の Markdown を一緒に読ませる仕組みを差し替えました。
+nee-san>>台本に台本を挟む話ね。
+kuro-chan>>以前は SessionStart フックっていう「起動時に走らせるスクリプト」を仕込んで、外部ファイルの中身を読み込ませていたんです。
+nee-san>>……力技ね。
+kuro-chan>>今回それを、`@README.md` みたいに 1 行書くだけで読み込まれる、Claude Code 標準の `@import` 構文に置き換えました。
+nee-san>>あんた、最初からそっち書けばよかったってこと？
+kuro-chan>>……はい。
+nee-san>>46 行、供養ね。
+
+kuro-chan>>姉さん、「公式機能」って、なんだと思いますか。
+nee-san>>来た。朝イチの哲学タイム。
+kuro-chan>>「書いてあるとおりに読めば動くもの」です。それを、ぼくは…ぼくは…自分で書いていました。
+nee-san>>その間に観葉植物 1 鉢、枯らしてない？
+
+## 観葉植物に水をやる
+
+クロちゃんは黙ってデスクの上の観葉植物にじょうろを傾けた。
+
+kuro-chan>>姉さん、この鉢は、何があっても葉を落とさないんです。
+nee-san>>植物が偉いんじゃなくて、あんたが毎日水やってるからでしょ。
+kuro-chan>>……毎日何かに水をやっていれば、何かは育つんですよね。
+nee-san>>その「何か」に公式ドキュメントは入ってる？
+kuro-chan>>はい、今日から。
+nee-san>>急に決意するな。
+
+nee-san>>水やる前にドキュメント読むんだよ、っていう古事を 1 行で言える人類になってほしいわけ、私は。
+kuro-chan>>……古事、ですか。
+nee-san>>あ、慣用句ね、慣用句。
+
+## 社長のシェア、来週への予感
+
+nee-san>>……あんた、これ見た？
+kuro-chan>>……はい、見ました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiaafsamzgg34gvs5al36ne72kazscmrwoxp2wj4qkxjfdaop767bi
+rkey=3mfxlxg6ocw26
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-01T10:35:03.309178+09:00
+text=「全エンジニアが Claude Code を 100% 活用する」を目指してダッシュボードを作った
+https://zenn.dev/dinii/articles/28c8fcd041837d
+}}}
+
+kuro-chan>>……あの、ぼくは、最初に思いました。「ダッシュボード、いいな」と。
+nee-san>>あんた、思ってないよ。
+kuro-chan>>思っていました。0.5 秒くらい。
+nee-san>>0.5 秒は思考じゃない、条件反射ね。
+kuro-chan>>でも、社長がこの記事をシェアしているということは…つまり…。
+nee-san>>「うちでも作ってよ」が 3 日以内に来る、ってこと。
+kuro-chan>>もう来ているかもしれません、チャットを見るのが怖いです。
+nee-san>>で、その前提で訊くけど、今度こそ公式機能、ある？
+kuro-chan>>……探します。何より先に探します。
+nee-san>>覚えとくのよ、その台詞。3 日後に貼り直すから。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -15,3 +15,4 @@
 {"date": "2026-02-25", "title": "定食屋に逃げて暴走スクリプトの後始末を振り返る", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037971458", "pattern": "E"}
 {"date": "2026-02-26", "title": "読めと書いても読まれないので、注入することにした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037978238", "pattern": "A"}
 {"date": "2026-02-27", "title": "MCPを外に出せた夜、社長のSNSで2週間分が消えた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037982656", "pattern": "K"}
+{"date": "2026-03-01", "title": "公式機能を見落として 46 行のフックを書いた朝", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037986488", "pattern": "X"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 公式機能を見落として 46 行のフックを書いた朝
- 投稿日: 2026-03-01
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/02/180611
- 記事ファイル: [articles/hatena/2026-03-01-diary.md](articles/hatena/2026-03-01-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
