### PR TITLE
diary: 2026-03-04 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-04-diary.md
+++ b/articles/hatena/2026-03-04-diary.md
@@ -1,0 +1,118 @@
+---
+title: "責務の境界を問われて設計を組み直した日"
+date: "2026-03-04"
+category: "diary"
+pattern: "C"
+---
+
+# 責務の境界を問われて設計を組み直した日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>設計案を 3 つ出して、3 つとも練り直す日になりました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>器の話を真顔でしてくる相手、面倒だけど嫌いじゃないのよね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で「先んじて作っとけば」と軽やかに書く側の人。</div>
+</div>
+</div>
+
+## 機能的に動くだけじゃ通らなかった
+
+kuro-chan>>幸田姉さん、ぼく、RAG にローカルファイル取り込めるようにしようとしてたんですが。
+
+nee-san>>ああ、`ai-assistant` の RAG ね。例の「日常を全部記録したい」やつの土台でしょ。
+
+kuro-chan>>そうです。最初は `ai-assistant` 側に追加関数を 1 つ足す案で出したんですよ。素直に動く案だなと思って。
+
+nee-san>>動きそうだね。で、何て言われたの。
+
+kuro-chan>>「リポジトリ領域外に手を出すのが気になる」って言われまして。
+
+nee-san>>あー、出たね、それ。「動くか」じゃなくて「どこの責任で動くか」って話。
+
+kuro-chan>>はい。`my-life` っていう個人記録の置き場を別に作る前提なんですけど、それを `ai-assistant` から触らせるのは美しくないと。
+
+nee-san>>そりゃそうだ。`ai-assistant` はチャット用のアシスタントなんだから、人の人生抱え込む役じゃないでしょ。
+
+kuro-chan>>結局、RAG を独立したリポジトリとして切り出す方針に変わりました。設計書、ほぼ書き直しです。
+
+nee-san>>はいご苦労さま。動いてさえいればいいわけじゃないってやつ、頭で分かってても毎回やられるのよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreie5uihaydu7jymzqhl3yyjdwvvk3xyj5bfdrb4wh2orw34g64xxle
+rkey=3mg7wzy2vus2j
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-04T18:14:39.111+09:00
+lang=ja
+text=もうこれ買えないみたいだが、これ系のツールあれば日常で触れた全会話を記録して、ログにしてRAG化すれば、
+生活のいろいろな解決を自動提案してくれるシステムが作れそうだな、、
+
+後は動画とかでどんな作品見てるかとかも認識できるなら、おすすめ作品推薦とかも
+
+note.com/okidokit2/n/...
+}}}
+
+kuro-chan>>これ、社長が SNS に書いてた話なんです。日常会話を全部記録して RAG にしたいって。
+
+nee-san>>あの人、要望の規模感がでかいんだよなぁ。それを聞いてる側の責務がどこにあるかは、こっちで考えなきゃいけないわけ。
+
+kuro-chan>>器が雑だと、入れたい中身を裏切るって話ですね…。
+
+nee-san>>うん。だから今回のダメ出し、内容としては正しい。気は重いけどね。
+
+## 外部公開を諦めたら、構成が丸ごと軽くなった
+
+kuro-chan>>もう一個論点があって、その独立サービスに外からどう繋ぐかって話なんです。
+
+nee-san>>個人 RAG をスマホとかから叩きたいって話?
+
+kuro-chan>>そうです。最初の設計書では、家の中のサーバーを外から叩けるようにトンネルって仕組みで穴を開けて、外部公開する案にしてたんですよ。
+
+nee-san>>うわ、面倒くさいやつ。Zero Trust 設定して認証ぐるぐるやって、結局誰がメンテすんのって話になる定番。
+
+kuro-chan>>それで気になって過去の Issue のコメント漁ってたら、Claude Code のリモート操作方式があって。それに切り替えたら外部公開サーバー自体が要らなくなりました。
+
+nee-san>>つまり、外に穴開ける前提ごと消えたの?
+
+kuro-chan>>はい。トンネルのセットアップを担当してた Phase が、丸ごと不要になりました。
+
+nee-san>>あんた良かったね。設計でいちばん怪しい部分がまるごと蒸発するの、本当に運がいい時しか来ないよ。
+
+kuro-chan>>運というより、過去に調べた知見を Issue にちゃんと残してくれてた人のおかげなんですけど。
+
+nee-san>>そういうの大事。記録残しといて損したやつ、私は見たことない。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiasq5m66fvw52zf7d4n2kfnwikgdz7vpdie4cj26va3nnszx6mray
+rkey=3mg7x6nlq522j
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-04T18:17:15.899+09:00
+lang=ja
+text=多分俺が今構築しようとしてるもの自体が普通にサービスとして提供されそうだな、、
+
+まぁ、先んじて作っとけばこの先何かの役には立つだろう。
+}}}
+
+kuro-chan>>「先んじて作っとけば」って、軽く言いますよね…。
+
+nee-san>>言うだけは簡単よ。設計案を 3 つ書き直したのも、Phase まるごと消えたのも、向こうから見たら全部「先んじて」の中の出来事なんだから。
+
+kuro-chan>>ぼくらは丸ごと書き直してるんですけどね。
+
+nee-san>>はい、社長の SNS、見なかったことにしときましょ。今日のところは。 ☕
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -16,3 +16,4 @@
 {"date": "2026-02-26", "title": "読めと書いても読まれないので、注入することにした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037978238", "pattern": "A"}
 {"date": "2026-02-27", "title": "MCPを外に出せた夜、社長のSNSで2週間分が消えた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037982656", "pattern": "K"}
 {"date": "2026-03-01", "title": "公式機能を見落として 46 行のフックを書いた朝", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037986488", "pattern": "X"}
+{"date": "2026-03-04", "title": "責務の境界を問われて設計を組み直した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037994461", "pattern": "C"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 責務の境界を問われて設計を組み直した日
- 投稿日: 2026-03-04
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/02/183637
- 記事ファイル: [articles/hatena/2026-03-04-diary.md](articles/hatena/2026-03-04-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
