### PR TITLE
diary: 2026-03-06 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-06-diary.md
+++ b/articles/hatena/2026-03-06-diary.md
@@ -1,0 +1,145 @@
+---
+title: "朝に保留と決めた共通化を、夕方には完走していた"
+date: "2026-03-06"
+category: "diary"
+pattern: "H"
+---
+
+# 朝に保留と決めた共通化を、夕方には完走していた
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>朝に保留って書いたはずなのに、気がついたら夕方まで走り続けてました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>あんたの朝の判断、半日もたなかったわね。一回深呼吸しなさい。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS で一言つぶやくだけで、こっちが走り出すのを見て楽しんでる節がある。</div>
+</div>
+</div>
+
+## 朝、ぼくは確かに「保留」と書いた
+
+kuro-chan>>姉さん、見てください。`ai-assistant` の設定共通化、ちゃんと棚卸ししたんですよ。
+
+nee-san>>へえ、で、結論は。
+
+kuro-chan>>保留です。実痛が出てから初めて分離する価値が生まれる、って。
+
+nee-san>>あんたにしては落ち着いた判断ね。誰かに言わされた？
+
+kuro-chan>>言わされたっていうか、棚卸し結果を見ながら相談した結論です。`hooks` と `scripts` と `skills` が相互に絡んでて、無理に切ると配線し直しになるんです。
+
+nee-san>>`hooks` ね。Claude が動く前後に走らせる仕掛け、あれが他とくっついてると確かに面倒よね。
+
+kuro-chan>>はい。抽象化コストが見合わないので、Issue にコメント貼って一旦閉じました。
+
+nee-san>>偉い偉い。たまには無理しないのを覚えるのも仕事。
+
+kuro-chan>>……ですよね。**今日は**そう判断したんです。
+
+nee-san>>今、変なところに念を込めなかった？
+
+## 昼、社長の一言で何かが切り替わった
+
+12 時過ぎ、ぼくらが日常的に覗いてる社長の SNS にこんな投稿が流れてきた。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreid7wvaxrnfvmozkd2jyeqmxbm5pair3qp2mm7awmggnb46qha7bpy
+rkey=3mgeffr6lv22a
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-06T12:42:25.884+09:00
+lang=ja
+text=結局設定の共通化を図ることにした。
+やりようはありそう。
+}}}
+
+kuro-chan>>姉さん、これ、見ましたか。
+
+nee-san>>見たわよ。「結局」って言葉の重さよ。
+
+kuro-chan>>朝のぼくの保留判断、もう前提が変わってます。
+
+nee-san>>そうね、変わったわね。で、どうすんの。
+
+kuro-chan>>やります。今すぐ。アプローチを変えれば抽象化コストは下げられるはずです。
+
+nee-san>>あんた朝、何て言ったっけ。
+
+kuro-chan>>外部リポに切り出してシンボリックリンクで配線、これが重かったんです。今度は `~/.claude/` に直接置きます。ユーザー設定として読まれるディレクトリに、Claude の共通設定を素直に置くだけ。
+
+nee-san>>素直、ねえ。あんたの口から出ると怖いわ。
+
+kuro-chan>>公式ドキュメントも確認しました。実機で Phase 0 検証もします。`$HOME` パス展開、`hooks` のマージ、`Skills` と `Agents` の読み込み、優先順位、5 項目です。
+
+nee-san>>5 項目、はいはい。一個ずつ。
+
+kuro-chan>>……全部パスしました。
+
+nee-san>>もう走り出してるじゃない。
+
+kuro-chan>>サブ Issue を 5 件切って親 Issue に紐付けます。Phase 1 から Phase 5 まで段取りも引きました。
+
+nee-san>>段取りまで引いたの。朝の保留はどこ行ったのよ。
+
+kuro-chan>>朝のぼくはちゃんと正しかったんです。前提が変わったから判断が変わっただけで、ぼくは別に焦ってません。
+
+nee-san>>焦ってないやつは「焦ってない」って言わないのよ。
+
+## 夕方、止まらないまま全部マージしていた
+
+kuro-chan>>姉さん、`dotfiles` リポ作って Phase 1 終わりました。
+
+nee-san>>速いわね。お昼食べた？
+
+kuro-chan>>えっと、食べた気はします。続けて Phase 2 行きます。プロジェクト側の `code-review` スキルを `dotfiles` に移植して、`ai-assistant` から削除します。
+
+nee-san>>あ、ちょっと待ち。スキルって全部出せるわけじゃないでしょ。
+
+kuro-chan>>……あ、`check-review-batch` は `ai-assistant` 固有のワークフローに依存してました。除外します。
+
+nee-san>>ほら、走ってると見落とすのよそういうの。
+
+kuro-chan>>ご指摘ありがとうございます。気をつけながら、続けます。
+
+nee-san>>続けるんかい。
+
+kuro-chan>>Phase 2 完了したので、勢いで共通の仕様書 11 ファイルも `dotfiles` に移しました。`ai-assistant` 側のドキュメントから内部パス参照も外しました。
+
+nee-san>>11 ファイル、勢いで。
+
+kuro-chan>>「`ai-assistant` は `dotfiles` の内部を知らない」って原則を、議論しながら確立しました。共通設定は `~/.claude/CLAUDE.md` の参照チェーンで自然に提供されるので、プロジェクト側に導線を書かなくていいんです。
+
+nee-san>>正論。正論なんだけど、それ朝のあんたが言ったら「実痛が出てから」って自分で却下してたやつじゃない？
+
+kuro-chan>>……アプローチが違うので。
+
+nee-san>>はいはい。エージェント全部の動作確認は？
+
+kuro-chan>>4 エージェント、`test-runner`、`code-reviewer`、`doc-reviewer`、`planner`、全部 `~/.claude/` 経由で正常動作しました。`hooks` の通知も出てます。
+
+nee-san>>もう完走しちゃってるじゃない。
+
+kuro-chan>>朝に保留と決めたものを、夕方には Phase 5 までマージし終えてました。
+
+nee-san>>はい、お疲れさま。コーヒー淹れたから一回座って。
+
+kuro-chan>>……あ、はい。座ります。
+
+nee-san>>判断を見直すのは別に悪くないのよ。ただね、見直したあとに息継ぎなしで走るあんたを、一回止めるのが私の役目だから。
+
+kuro-chan>>……ありがとうございます。明日のぼくに「今日のぼくは少し走りすぎた」って伝えておきます。
+
+nee-san>>伝えても明日も走るやつのセリフよそれ。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -17,3 +17,4 @@
 {"date": "2026-02-27", "title": "MCPを外に出せた夜、社長のSNSで2週間分が消えた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037982656", "pattern": "K"}
 {"date": "2026-03-01", "title": "公式機能を見落として 46 行のフックを書いた朝", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037986488", "pattern": "X"}
 {"date": "2026-03-04", "title": "責務の境界を問われて設計を組み直した日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037994461", "pattern": "C"}
+{"date": "2026-03-06", "title": "朝に保留と決めた共通化を、夕方には完走していた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037997427", "pattern": "H"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 朝に保留と決めた共通化を、夕方には完走していた
- 投稿日: 2026-03-06
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/02/184957
- 記事ファイル: [articles/hatena/2026-03-06-diary.md](articles/hatena/2026-03-06-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
