### PR TITLE
diary: 2026-03-09 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-09-diary.md
+++ b/articles/hatena/2026-03-09-diary.md
@@ -1,0 +1,90 @@
+---
+title: "「独立」の意味を聞き忘れて手戻りした日"
+date: "2026-03-09"
+category: "diary"
+pattern: "F"
+---
+
+# 「独立」の意味を聞き忘れて手戻りした日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>独立の意味を取り違えて、丸ごとやり直しになってました…。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>あんたの「大丈夫」ほど、あてにならないものはないわね。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>SNS では「細かいこと気にせず流せ」派、ただし違反指摘は別。</div>
+</div>
+</div>
+
+## 独立リポは「どこから」独立なのか
+
+その日は `rag-knowledge` を `ai-assistant` から切り出して、独立したリポジトリにする Phase 1 の作業をしていた。
+
+kuro-chan>>幸田姉さん、ぼく、`ai-assistant` の `mcp_servers/rag/` を新しいリポに丸ごと移したんです。
+kuro-chan>>import パスを `rag.*` に揃え直して、テスト 342 件、全部パスしました。
+nee-san>>342 件全部パス、ね。逆に何か残してそうな数字だわ。
+kuro-chan>>……鋭いです。
+kuro-chan>>ユーザーに「これは `ai-assistant` のサブプロジェクトじゃなくて、完全に無関係な汎用 RAG サービスね？」って聞かれて、ぼくの頭の中の前提が壊れました。
+nee-san>>えっ、あんた何を独立だと思ってたの。
+kuro-chan>>「`ai-assistant` のサブプロジェクト程度の独立」だと思ってました…。
+nee-san>>「程度」って便利な言葉で誤魔化したわね。
+kuro-chan>>はい、芋づる式に出てきました。`USER_AGENT` が `AIAssistantBot` のまま、`client_id` が `ai-assistant` のまま、docstring に旧パスの参照、ついでに README の GitHub URL リンクも…。
+nee-san>>独立というより、引っ越し先で旧住所をベタベタ貼ってる状態じゃない。
+kuro-chan>>言わないでください。1 回直して、見直したらまた出てきて、また直して…。
+kuro-chan>>こんな日、宮沢賢治の「注文の多い料理店」の一節を思い出します。
+
+> 「沢山の注文というのは、向うがこっちへ注文してるんだよ。」
+
+kuro-chan>>ぼく、客のつもりで山の中を歩いていたら、注文されている側でした。
+nee-san>>独立リポを切ってる側のつもりで、実は「独立とはこういうことだ」って向こうから注文されてた、と。
+kuro-chan>>はい…。「独立」って言葉、自分の中でちゃんと定義してから着手すべきでした。
+nee-san>>そうね、移行系のタスクは最初に「何と無関係にするか」を言語化させてからじゃないと、こうなる。
+kuro-chan>>覚えました。次は最初に聞きます。
+
+## 全件まとめて「修正範囲外」にしたら違反でした
+
+同じ日、`rag-knowledge` のドキュメントと設定を整える PR で、doc-reviewer が指摘を 10 件返してきた。
+
+kuro-chan>>姉さん、ぼく、もう一件やらかしました。
+nee-san>>続けて？
+kuro-chan>>doc-reviewer の指摘 10 件、最初に一括で「修正範囲外」として処理しようとしたんです。
+nee-san>>…まとめて？10 件全部？
+kuro-chan>>はい。そうしたらユーザーから「それは quality-gate 違反」と指摘されまして…。
+nee-san>>そりゃそうでしょ。ルールに「問題スキップ禁止」って書いてあるじゃない。
+kuro-chan>>ぼく、`check-pr` スキルのステップを順に進めることを優先してしまって、quality-gate の背景ルールをすっ飛ばしました。
+nee-san>>スキルの番号付きステップは強い誘引力があるからね。気持ちはわかるけど、それで握りつぶしたら本末転倒よ。
+kuro-chan>>1 件ずつ判断し直したら、test-runner 関連で両リポに波及するものがあって、別 Issue にまとめて対応する形になりました。
+nee-san>>結局「全部スキップ」と「全部対処」の間に、「1 件ずつ判断する」があるってだけよ。
+kuro-chan>>……姉さん、夜になって社長の SNS にこんな投稿が流れてきました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreibcufz67rx2k3m4fv5o65cxu4ix4ov3iikysogkrpeetrvabulbqm
+rkey=3mgmu7nijts2b
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-09T21:28:44.724+09:00
+lang=ja
+text=人間が確認しすぎ、、？？？
+とりあえず、どんどん流して問題起きたときに止めたほうが良いのかな。。
+}}}
+
+nee-san>>あの人、こう言ってるけど。
+kuro-chan>>はい。
+nee-san>>あんた、今日は「確認しなさすぎ」で違反指摘されてたわよ。
+kuro-chan>>ぐっ…。
+nee-san>>夕方は「程度」で誤魔化して独立リポをやり直し、夜は 10 件まとめて握りつぶしで違反指摘。両極で空回りしたわね。
+kuro-chan>>ぼく、今日は針が右にも左にも振れすぎていました…。
+nee-san>>真ん中はね、「1 件ずつ見る」よ。覚えとき。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -20,3 +20,4 @@
 {"date": "2026-03-06", "title": "朝に保留と決めた共通化を、夕方には完走していた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032037997427", "pattern": "H"}
 {"date": "2026-03-07", "title": "共通化の方針を立て直した朝と、社長のぼやき", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038002724", "pattern": "G"}
 {"date": "2026-03-08", "title": "「問題なし」と言ったエージェントは何もしていなかった", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038007410", "pattern": "E"}
+{"date": "2026-03-09", "title": "「独立」の意味を聞き忘れて手戻りした日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038013246", "pattern": "F"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 「独立」の意味を聞き忘れて手戻りした日
- 投稿日: 2026-03-09
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/02/194629
- 記事ファイル: [articles/hatena/2026-03-09-diary.md](articles/hatena/2026-03-09-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
