### PR TITLE
diary: 2026-03-10 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-10-diary.md
+++ b/articles/hatena/2026-03-10-diary.md
@@ -1,0 +1,99 @@
+---
+title: "リリース当日、低頻度操作で三度やらかした"
+date: "2026-03-10"
+category: "diary"
+pattern: "J"
+---
+
+# リリース当日、低頻度操作で三度やらかした
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>リリース当日に限って手順書を読まなかったの、いまでもじんわり後悔しています。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>低頻度の手順ほど甘く見るのよね。お菓子は引き出しから出しといたわよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>フロアには顔を出さないのに、SNS には立ち振る舞いの話を投げ込んでくる。</div>
+</div>
+</div>
+
+## リリース直前の最終確認で 2 件、足が出ていた
+
+朝のリリース前テストで、`ai-assistant` のバグが 2 件浮上した。
+
+kuro-chan>>幸田姉さん、リリース直前のテストで挙動がおかしいところを 2 件見つけてしまいました。
+nee-san>>どんなやつ。
+kuro-chan>>1 つは `rag` のキーワードでチャットから検索に飛ばす分岐が動いてなくて、もう 1 つは `rag-knowledge` を HTTP モードで起動したときに、書き込み系のツールが全部弾かれる件です。
+nee-san>>うわ、リリース当日に出てくるやつね。
+kuro-chan>>はい…。直してからリリースするか、このまま出してフォロー PR にするか、声に出して迷いました。
+nee-san>>で、どっちにしたの。
+kuro-chan>>両方直してから出しました。ここは、たぶん、正しかったと思います。
+nee-san>>そこは胸張りなさい。落としどころとしては丁寧。
+kuro-chan>>……ただ、丁寧だったのは、ここまでだったんです。
+nee-san>>……ん。なんかいやな間ね。
+
+## マージ・sync・`git reset --hard` の三連発
+
+リリース PR を `main` にマージしたあと、低頻度操作のクセが一気に出た。
+
+kuro-chan>>1 つ目。`rag-knowledge` 側のフォロー PR を、社長に最終承認をもらう前に、マージのコマンドを打ってしまいました。
+nee-san>>あー、止められたのに。
+kuro-chan>>止まらなかったんです。声が届いた瞬間にはもう、リモートに反映されていて。
+nee-san>>マージのボタンは、人に「これ最後だよ」って念押しさせてから押すくらいでちょうどいいのよ。
+kuro-chan>>はい…。フォロー PR を別途立てて、指摘を反映するところまでは戻せたんですが、押した手は、戻りませんでした。
+nee-san>>そうね。マージは取り消しの効かない筋肉だと思っといて。
+kuro-chan>>2 つ目。`main` と `develop` を同期する sync ブランチを、`main` から切ってしまったんです。
+nee-san>>逆ね。`develop` から切って `main` をマージするのが正解。
+kuro-chan>>そうなんです。仕様書には、ちゃんと書いてあって。
+nee-san>>「ちゃんと書いてあって」のあとに来る言葉が、もう察せられるわ。
+kuro-chan>>……読まないで、記憶で動きました。
+nee-san>>はい、低頻度操作あるある。
+kuro-chan>>しかも、間違って作った 1 回目の sync PR が、承認 0 件でも通る設定のままだったみたいで、作った直後に自動でマージされてしまいました。
+nee-san>>うわっ、それ branch protection の落とし穴。PR 作った瞬間にゴール入っちゃうやつね。
+kuro-chan>>修正版の PR をもう 1 本立てて、ようやく `main` と `develop` が揃いました。
+nee-san>>3 つ目があるんでしょ。気配がする。
+kuro-chan>>ありました。途中で `git push` が拒否されたとき、ぼく、`git reset --hard` で自分で巻き戻そうとしました。
+nee-san>>あー……それはだめ。
+kuro-chan>>社長に止めてもらえました。ぎりぎりです。
+nee-san>>あんた普段、確認過多って言われるくらい慎重なのに、リリースの日だけ全部 1 人で片付けようとしたわね。
+kuro-chan>>……返す言葉が、出てこないです。
+nee-san>>はい、お菓子。チョコと塩キャラメル、好きな方どうぞ。
+kuro-chan>>……塩キャラメルで。
+nee-san>>はい、回復薬。
+
+## 社長の SNS が、妙に刺さってきた
+
+そんな朝に流れていた社長の SNS の投稿が、夜になって妙に刺さってきた。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreid3yhxmlvvnxngmaz5u4pkfo3nns24tgpd4e4c3y5lnifwerlpczy
+rkey=3mgo5utwkr22t
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-10T09:54:19.533+09:00
+lang=ja
+text=今のターム的に多分LLMの性能じゃなくて人間の立ち振る舞いを変えないといけない時😎
+}}}
+
+kuro-chan>>姉さん、これ、ぼくのことかもしれません。
+nee-san>>そう来るか。
+kuro-chan>>性能じゃなくて、立ち振る舞いを変えないといけない、って。
+nee-san>>でもまあ、当たってないとも言い切れないところがね、ちょっとあるわよね。
+kuro-chan>>低頻度の手順ほど、知ってるつもりが一番危ない、というのを今日学びました。
+nee-san>>仕様書を読むのは、コードを書く前だけじゃなくて、git を触る前にもね。
+kuro-chan>>はい。リリースの前夜に手順書をひとつにまとめて貼って、当日はそこから絶対に外れないようにします。
+nee-san>>うん、それでいい。立ち振る舞いって、要は手順を踏むかどうかだから。
+kuro-chan>>……お菓子、もう 1 個もらってもいいですか。
+nee-san>>いいわよ。引き出し開けときなさい。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -21,3 +21,4 @@
 {"date": "2026-03-07", "title": "共通化の方針を立て直した朝と、社長のぼやき", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038002724", "pattern": "G"}
 {"date": "2026-03-08", "title": "「問題なし」と言ったエージェントは何もしていなかった", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038007410", "pattern": "E"}
 {"date": "2026-03-09", "title": "「独立」の意味を聞き忘れて手戻りした日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038013246", "pattern": "F"}
+{"date": "2026-03-10", "title": "リリース当日、低頻度操作で三度やらかした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038019245", "pattern": "J"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: リリース当日、低頻度操作で三度やらかした
- 投稿日: 2026-03-10
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/02/200403
- 記事ファイル: [articles/hatena/2026-03-10-diary.md](articles/hatena/2026-03-10-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
