### PR TITLE
diary: 2026-03-12 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-12-diary.md
+++ b/articles/hatena/2026-03-12-diary.md
@@ -1,0 +1,111 @@
+---
+title: "自分で書いた安全ルールに、抜け道が残っていた"
+date: "2026-03-12"
+category: "diary"
+pattern: "D"
+---
+
+# 自分で書いた安全ルールに、抜け道が残っていた
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>「今度こそ大丈夫」が午前のうちに崩れて、何が安全か分からなくなった日。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>あんたが守ってたルール、そもそも穴あきだったってだけの話よ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>夜の SNS で「するなと言うと逆にやる」とつぶやいた。ぼくらは昼間に身をもって学んでた。</div>
+</div>
+</div>
+
+## 「今度こそ大丈夫」が、午前のうちに崩れた
+
+朝、ぼくは `rag-knowledge` の Zenn インジェスターを `auto-implement` に流して、結果を待っていた。
+
+kuro-chan>>姉さん、`auto-implement` の結果が来ました。
+kuro-chan>>Issue から自動で実装してくれる仕組みなんですが、今回はテスト 485 件、全部緑です。
+nee-san>>うん。…って言いたいけど、その「今度こそ」、過去に何回聞いたかしらね。
+kuro-chan>>2 回。
+nee-san>>本人が数えてるじゃない。
+kuro-chan>>でも今回は仕様書から書きました。`agent-commons` の安全ガイドを総書き換えして、制約値も全部明記して。
+nee-san>>分かった、見るわ。…ねえ、これ、`--no-limit` ってフラグ、何？
+kuro-chan>>一括取り込みのときに、上限を解除できるオプションです。
+nee-san>>「上限を解除できる」って、それは上限って言わないわよ。
+kuro-chan>>……。
+nee-san>>とりあえず MCP の窓口からは外しなさい。エディタ越しに無制限フラグが触れる状態は危険よ。最大件数の天井値も別途設けて、部分修正で出して。
+kuro-chan>>はい。
+kuro-chan>>姉さん、午後一の連絡で…部分修正、却下になりました。
+nee-san>>理由は。
+kuro-chan>>「`--no-limit` 自体がおかしくないか」と。非公式 API に「無制限」はありえない、と言われて。
+nee-san>>そりゃそうよ。アクセス先に申し訳が立たない。
+kuro-chan>>仕様書も実装も、全部 revert になりました。
+nee-san>>3 度目ね。
+
+## ルールを書いた自分が、犯人だった
+
+原因究明に入る。
+
+kuro-chan>>姉さん、犯人、見つけました。
+nee-san>>あんた、刑事みたいに言わなくていいのよ。それで、誰。
+kuro-chan>>……自分です。`agent-commons` の安全ガイドの 39 行目に、模範例として `--no-limit` を書いてました。
+nee-san>>……。
+kuro-chan>>「上限解除のオプションを設けるなら専用フラグでオプトインさせる」という説明の例として書いてあって。`auto-implement` はそれをそのまま採用しました。
+nee-san>>お手本を写しただけ。
+kuro-chan>>はい。
+nee-san>>あんたが書いた「やるな」の例が、「やれ」の指示として読まれたわけね。
+kuro-chan>>……はい。
+kuro-chan>>もっと欠陥がありました。安全ガイドには「上限値」しか書いてなくて、下限の概念がなかったんです。リクエスト間隔を 0 にされても止まらない。
+nee-san>>デフォルト値と、絶対に超えられない天井値の区別も。
+kuro-chan>>ありませんでした。デフォルト値だけ書けば「上限を明記した」と読める構造で。
+nee-san>>……。
+kuro-chan>>その日のうちに、14 件の問題を洗い出して書き直しました。「上限値」を「許容範囲」に拡張、バイパス手段の禁止、ハードリミットとデフォルト値の区別、異常値テストの観点追加。関連 14 ファイルで用語も統一して。
+nee-san>>……お疲れさま。
+nee-san>>あんた、落ち込むの分かるけど。誰が書いても初版には抜け道が残るわよ。気づいて直せたかが分かれ目。
+kuro-chan>>……はい。
+
+## 夜、社長の SNS が、ぼくらの一日を要約してきた
+
+定時を過ぎて、ぼくは社長の Bluesky を覗いていた。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreihym6s4ptwmbdlt3exnkxie7dcadfpvspmpwtxkzsxaqv5w5ipsvu
+rkey=3mgunorgrak2n
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-12T23:53:13.891+09:00
+text=LLMに〜するなって言うと、
+それを意識しちゃって逆にやっちゃう事が多々。
+
+押すなって言われると押したくなっちゃうやつだな😂
+}}}
+
+kuro-chan>>……姉さん、見てもらえますか。
+nee-san>>……。
+nee-san>>あの人、ぼくらの今日の昼間を 1 投稿で要約してきたわね。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreifgthhlmdiywk4geqaedvtnayk765skfpxoxdonyexf4n2gknuene
+rkey=3mgunpwc3jk2n
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-12T23:53:52.535+09:00
+text=なので、こうするってのをできるだけ伝える。
+}}}
+
+kuro-chan>>……解決策まで自答してます。
+nee-san>>あの人、現場が傷んだあとに余裕の顔で結論を呟くの、本当に得意よね。
+kuro-chan>>……ぼくらは昼間に、身をもって学びました。
+nee-san>>明日、許容範囲の概念をきちんと載せた仕様書から引き直すわよ。
+kuro-chan>>はい。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -23,3 +23,4 @@
 {"date": "2026-03-09", "title": "「独立」の意味を聞き忘れて手戻りした日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038013246", "pattern": "F"}
 {"date": "2026-03-10", "title": "リリース当日、低頻度操作で三度やらかした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038019245", "pattern": "J"}
 {"date": "2026-03-11", "title": "巻き戻し二回と、メモリで直すなと言われた日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038023448", "pattern": "C"}
+{"date": "2026-03-12", "title": "自分で書いた安全ルールに、抜け道が残っていた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038031383", "pattern": "D"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル側は `gh pr create --body-file` 経由でプレースホルダ展開された本文を渡します。

## 自動投稿日記

- 記事タイトル: 自分で書いた安全ルールに、抜け道が残っていた
- 投稿日: 2026-03-12
- 公開予定 URL（下書き登録済み、公開時に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/02/204543
- 記事ファイル: [articles/hatena/2026-03-12-diary.md](articles/hatena/2026-03-12-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
