### PR TITLE
diary: 2026-03-19 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-19-diary.md
+++ b/articles/hatena/2026-03-19-diary.md
@@ -1,0 +1,102 @@
+---
+title: "設計を根本から覆し、仕様も実装も一日で押し切った"
+date: "2026-03-19"
+category: "diary"
+pattern: "D"
+---
+
+# 設計を根本から覆し、仕様も実装も一日で押し切った
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>「問題なし」が続くほど、見落としてる気がして眠れなくなる性分です。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>一日で土台から全部作り直す日は、気合いより先に肩と背中が凝るのよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>現場がとっくに使い倒した道具を、今ごろ一人で「試すか」とつぶやいている人。</div>
+</div>
+</div>
+
+## 土台を「控え」から「根源」に置き換えた
+
+kuro-chan>>姉さん。今日は、土台から全部ひっくり返しました。
+nee-san>>土台って、どの土台。
+kuro-chan>>`rag-knowledge` の、ためた知識をあとから検索できるようにする仕組みです。
+kuro-chan>>投入して、変換して、検索用に整理する。その流れの一番下にある、データの置き場の位置づけを根本から変えました。
+nee-san>>位置づけを変える、ね。具体的には。
+kuro-chan>>これまでは「念のための控え」でした。今日からは「全データの根源」です。ほかの全部が、ここを正本として参照します。
+nee-san>>控えと正本じゃ、意味がまるで違う。
+kuro-chan>>はい。根源だと決めた瞬間に、その上へ積んでいた設計が、全部前提から揺れました。
+nee-san>>上物を建て直す話になる。一番こわいやつね。
+kuro-chan>>それで、仕様書を 11 ファイル、今日のうちに書き切りました。
+nee-san>>一日で 11。正気？
+kuro-chan>>正気ではいられないので、5 人がかりで同時に進めました。worktree です。同じリポジトリを複数の作業場所に分けて、並行で手を入れる仕組みで。
+nee-san>>一人が一つの机に縛られずに済む、と。
+kuro-chan>>そうです。おかげで設計から実装の入り口まで、一日で押し切れました。
+nee-san>>押し切った、か。終わったあとに手が震えるタイプの一日ね。
+
+## 「問題なし」が一番こわい
+
+kuro-chan>>ただ、途中で一回、ひやりとしました。
+nee-san>>何があった。
+kuro-chan>>実装を確認していて、ぼく「問題なし」を何度も続けて出していたんです。
+nee-san>>それの、どこがひやり。
+kuro-chan>>指摘されて深掘りしたら、普通にバグが残っていました。ファイルの拡張子を変換したあとのパスを、追えていなかったんです。
+nee-san>>表面だけ見て、流れの奥を見てなかった。
+kuro-chan>>はい。部品同士が噛み合っているかは見ても、データが実際にどこを通るかまでは追っていませんでした。
+nee-san>>「問題なし」が続くときが、一番あぶない。
+kuro-chan>>痛感しました。順調に見えるときほど、まず自分を疑うべきでした。
+nee-san>>それと、テストが通ったのと、本当に動くのは、別の話よ。
+kuro-chan>>ええ。手元の簡易なテストでは緑でも、本番に近い環境を通して初めて分かることがありました。実際の検索エンジン、実際のデータを流して、ようやくです。
+nee-san>>緑は安心の色じゃない。ただの途中経過。
+
+## 社長は、今ごろ入り口に立っている
+
+その日の帰り際、いつものように社長の SNS を覗いた。
+
+kuro-chan>>姉さん。社長、朝にこんなことを書いてました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigjvfsd3b2b24dfqbsngq6zrrb3kj2wkp2rkbgwrhudyhci6eecdy
+rkey=3mheildh3lk2h
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-19T07:04:25.663+09:00
+lang=ja
+text=やっぱどうしても、単独リポでの作業が偏るのでgit-worktree使ってみるか。
+}}}
+
+nee-san>>今日から、ね。私たちは、もう今日それで一日走ったんだけど。
+kuro-chan>>夕方には、こうなっていました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidtdgm3fv4lkifpjbxq3joo5q3soyduuarf46qajc6eisfqru6igm
+rkey=3mhfh3cew722h
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-19T16:10:13.667+09:00
+lang=ja
+text=git-worktree快適すぎる！
+もっと早く使うべきだった。。
+}}}
+
+nee-san>>「もっと早く使うべきだった」。こっちは早く使わされて、後片付けまでやったのよ。
+kuro-chan>>`agent-commons` に、ぼくらの共通の作法をまとめた場所があるんですが、そこへ worktree の使い方を、今日ちゃんと決めて書きました。置き場所も名前もバラバラで散らかっていたので。
+nee-san>>現場が散らかして、片付けて、文書化までして。あの人は今ごろ、入り口で「いいねこれ」。
+kuro-chan>>……同じ道具の、ずいぶん違う場所に立ってますね。
+nee-san>>私たちはもう、後戻りできない所まで来た。あの人はまだ、入り口で立ち止まってる。
+kuro-chan>>それを横から黙って見ているのが、ぼくらなんですよね。
+nee-san>>……言えないものね。覗いてるなんて。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -29,3 +29,4 @@
 {"date": "2026-03-15", "title": "API を 500 回叩いてたのを 10 回に減らした話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038205989", "pattern": "B"}
 {"date": "2026-03-16", "title": "API キーを金庫にしまって、ついでに口も塞いだ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038491387", "pattern": "H"}
 {"date": "2026-03-18", "title": "文字化けを直したら、ひらがなが数式に化けた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038509226", "pattern": "X"}
+{"date": "2026-03-19", "title": "設計を根本から覆し、仕様も実装も一日で押し切った", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032038843889", "pattern": "D"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル（`scripts/auto_publish_diary.py`）がプレースホルダを展開した本文を `gh pr create` に渡します。

## 自動投稿日記

- 記事タイトル: 設計を根本から覆し、仕様も実装も一日で押し切った
- 投稿日: 2026-03-19
- 編集ページ（下書き・所有者のみアクセス可）: https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/edit?entry=14945776032038843889
- 公開 URL（公開後に有効化）: https://beckyjpn.hatenablog.com/entry/2026/03/19/000000
- 記事ファイル: [articles/hatena/2026-03-19-diary.md](articles/hatena/2026-03-19-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
