### PR TITLE
fix(auto-publish-diary): Phase 3 の --delete-branch を撤去し cleanup() で -D 強制削除へ変更 (#234)

### DIFF
--- a/.claude/skills/auto-publish-diary/SKILL.md
+++ b/.claude/skills/auto-publish-diary/SKILL.md
@@ -129,7 +129,7 @@ python scripts/auto_publish_diary.py finalize --article-path "$ARTICLE_PATH"
 ```
 
 - Phase 2: `publish_hatena.py` を subprocess 起動して下書き登録 → `published.jsonl` から `edit_url` を読み、編集ページ URL・公開 URL を組み立てる
-- Phase 3: git add / commit / push / `gh pr create` / `gh pr merge --squash --admin --delete-branch`
+- Phase 3: git add / commit / push / `gh pr create` / `gh pr merge --squash --admin`
 - Phase 4: 親リポへ戻り worktree 削除・ローカルブランチ削除・main 同期（削除失敗でも `status=ok`）
 - Phase 5: `status=ok` の result.json を書き込む
 - いずれかの Phase で失敗したら、`failed_phase` 付きの result.json を書き込み終了コード 1 で終了する

--- a/scripts/auto_publish_diary.py
+++ b/scripts/auto_publish_diary.py
@@ -334,7 +334,7 @@ def cmd_finalize(article_path: str) -> int:
 
     try:
         merge = _run(
-            ["gh", "pr", "merge", pr_number, "--squash", "--admin", "--delete-branch"],
+            ["gh", "pr", "merge", pr_number, "--squash", "--admin"],
             cwd=worktree_path,
             timeout=NETWORK_TIMEOUT,
         )
@@ -387,6 +387,9 @@ def build_pr_body(
 def cleanup(parent_repo: str, worktree_path: str, branch_name: str) -> bool:
     """worktree 削除・ローカルブランチ削除・親リポ main 同期。
 
+    前提: `gh pr merge --squash --admin` が成功した直後に限定して呼び出すこと。
+    未マージブランチに対して呼ぶと `git branch -D` で未マージ変更が失われる。
+
     Returns:
         worktree 削除に成功したか（Windows ロック等で失敗しても status=ok を保つため bool を返す）
     """
@@ -398,8 +401,9 @@ def cleanup(parent_repo: str, worktree_path: str, branch_name: str) -> bool:
         _run(["git", "-C", parent_repo, "worktree", "remove", "--force", worktree_path]).returncode
         == 0
     )
-    # マージ済みのみ削除する -d（-D 強制は使わない）。失敗は無視
-    _run(["git", "-C", parent_repo, "branch", "-d", branch_name])
+    # squash マージ後は -d が「not fully merged」で失敗するため -D で強制削除する。
+    # gh pr merge --admin --squash 成功直後に限定して呼ぶため安全。失敗は無視
+    _run(["git", "-C", parent_repo, "branch", "-D", branch_name])
     # squash マージ済みコミットをローカル main へ取り込む（失敗は無視）
     try:
         _run(


### PR DESCRIPTION
## Change type

- [x] fix（バグ修正）

## Summary

- `/auto-publish-diary` の Phase 3 で `gh pr merge --squash --admin --delete-branch` を worktree を cwd として実行していたため、`--delete-branch` が main 切替を試みて「'main' is already used by worktree at ...」で全停止していた問題を修正。`--delete-branch` を削除し、リモートブランチ削除は GitHub repo 設定 `delete_branch_on_merge: true` に委譲する
- これに伴い `cleanup()` の `git branch -d <branch>` を `-D` 強制削除に変更。`gh pr merge --squash` でマージされたローカルブランチは `-d` だと「not fully merged」で必ず失敗するため、`--admin --squash` 成功直後に限定して強制削除する
- `cleanup()` の docstring に呼び出し前提（`gh pr merge --squash --admin` 成功直後限定）を明記
- `.claude/skills/auto-publish-diary/SKILL.md` L132 の Phase 3 記述を実装に同期

## Test plan

- [x] 既存単体テスト（`tests/test_auto_publish_diary.py` 全 5 件 + 全体 192 件）pass
- [x] `gh` および `git branch -d/-D` の挙動は実証スクリプト（`/tmp/branch-d-test`）で squash マージ後に `-d` が必ず失敗し `-D` で成功することを確認
- [ ] 実機 QA はマージ後の通常運用（次回 Slack reminder 起動）で確認する方針（万一 worktree/ローカルブランチ残置が発生した場合は fix forward）

## Related issues

Closes #234

関連 Issue:
- becky3/ai-assistant#848（本 PR の調査過程で発見、ai-assistant 側 Slack 通知の汎用化として別 Issue 化）