### PR TITLE
fix(auto-publish-diary): cleanup の stderr 捕捉と gh pr merge の state 再確認 (#240) (#219)

### DIFF
--- a/.claude/skills/auto-publish-diary/SKILL.md
+++ b/.claude/skills/auto-publish-diary/SKILL.md
@@ -41,38 +41,25 @@ argument-hint: "(引数なし)"
 
 呼び出し元への結果伝達は `scripts/auto_publish_diary.py` が書き出す **レスポンスファイル** `$PARENT_REPO/.tmp/auto-publish-diary/result.json` で行う。配置先は **親リポ固定**（worktree は cleanup で削除されるため）。`setup` 冒頭で前回残骸を削除し、成功時・失敗時の両方で必ず書き込む。
 
-成功時（全工程完了、worktree 削除済み）:
+dict 生成の SSoT は `scripts/write_auto_publish_result.py` の `build_result()`。
+result.json のスキーマ・各キーの意味・正規化ルール・`status` による分岐は同関数の docstring を参照する。
+実例の JSON サンプルは `tests/test_write_auto_publish_result.py` の各テストケース（ok/削除済み・ok/削除失敗・error 等）を参照する。
 
-```json
-{"status":"ok","article_path":"articles/hatena/YYYY-MM-DD-diary.md","edit_url":"https://blog.hatena.ne.jp/<ID>/<BLOG>/edit?entry=<entry_id>","public_url":"https://<BLOG>/entry/YYYY/MM/DD/000000","pr_url":"https://github.com/becky3/article-writer/pull/N","merged":true,"worktree_removed":true,"worktree_path":null}
-```
+`status` は `"ok"`（全 Phase 成功。`worktree_removed=false` の中間状態を含む）または `"error"`（任意 Phase で停止）の 2 値。スキーマのキー一覧（型と status 別出現条件のみ。各キーの意味・正規化ルールの SSoT は `build_result()` docstring）:
 
-成功時（worktree 削除失敗、その他は完了）:
-
-```json
-{"status":"ok","article_path":"...","edit_url":"...","public_url":"...","pr_url":"...","merged":true,"worktree_removed":false,"worktree_path":"D:/GitHub/becky3/article-writer-wt-auto-YYYYMMDD"}
-```
-
-失敗時（共通フィールドは同順。`worktree_removed` は失敗時も常に `false`）:
-
-```json
-{"status":"error","failed_phase":"<Phase 名>","error":"<エラー要約 1 行>","article_path":"<生成済みなら相対パス、なければ null>","edit_url":"<登録済みなら編集ページ URL、なければ null>","public_url":"<登録済みなら公開 URL、なければ null>","pr_url":"<作成済みなら URL、なければ null>","merged":false,"worktree_removed":false,"worktree_path":"<残置 worktree の絶対パス or null>"}
-```
-
-JSON フィールドの説明（全モード共通スキーマ）:
-
-| フィールド | 型 | 成功時 | 失敗時 |
+| フィールド | 型 | status="ok" | status="error" |
 |---|---|---|---|
-| `status` | string | `"ok"` | `"error"` |
-| `article_path` | string \| null | 生成記事の相対パス | 生成済みなら相対パス、なければ null |
-| `edit_url` | string \| null | はてなブログの編集ページ URL（`https://blog.hatena.ne.jp/<ID>/<BLOG>/edit?entry=<entry_id>`）。下書き状態でも所有者がアクセスできる | 登録済みなら URL、なければ null |
-| `public_url` | string \| null | 公開記事 URL（`https://<BLOG>/entry/YYYY/MM/DD/000000`）。記事日付ベースで算出。公開されるまでは 404 | 登録済みなら URL、なければ null |
-| `pr_url` | string \| null | 作成された PR の URL | 作成済みなら URL、なければ null |
-| `merged` | bool | true | false |
-| `worktree_removed` | bool | 削除済みなら true / 削除失敗時は false | false |
-| `worktree_path` | string \| null | 削除済みなら null / 削除失敗時は残置パス | 残置 worktree の絶対パス（worktree 作成前に失敗した場合は null） |
-| `failed_phase` | string | （省略） | 失敗 Phase 名（`environment` / `write` / `publish` / `git`）。`cleanup`（worktree 削除失敗）は仕様上 `status=ok` で終了するため現れない |
-| `error` | string | （省略） | エラー要約 1 行 |
+| `status` | string | 必須 | 必須 |
+| `article_path` | string \| null | 必須 | 必須 |
+| `edit_url` | string \| null | 必須 | 必須 |
+| `public_url` | string \| null | 必須 | 必須 |
+| `pr_url` | string \| null | 必須 | 必須 |
+| `merged` | bool | 必須 | 必須 |
+| `worktree_removed` | bool | 必須 | 必須 |
+| `worktree_path` | string \| null | 必須 | 必須 |
+| `worktree_remove_error` | string \| null | 必須 | 必須 |
+| `failed_phase` | string | キー省略 | 必須 |
+| `error` | string | キー省略 | 必須 |
 
 ### 終了コード
 
@@ -129,7 +116,7 @@ python scripts/auto_publish_diary.py finalize --article-path "$ARTICLE_PATH"
 ```
 
 - Phase 2: `publish_hatena.py` を subprocess 起動して下書き登録 → `published.jsonl` から `edit_url` を読み、編集ページ URL・公開 URL を組み立てる
-- Phase 3: git add / commit / push / `gh pr create` / `gh pr merge --squash --admin`
+- Phase 3: git add / commit / push / `gh pr create` / `gh pr merge --squash --admin`（merge が exit 非 0 のときは `gh pr view --json state` で `MERGED` を確認できれば継続。Why は「注意事項」参照）
 - Phase 4: 親リポへ戻り worktree 削除・ローカルブランチ削除・main 同期（削除失敗でも `status=ok`）
 - Phase 5: `status=ok` の result.json を書き込む
 - いずれかの Phase で失敗したら、`failed_phase` 付きの result.json を書き込み終了コード 1 で終了する
@@ -145,8 +132,9 @@ result.json への書き込みと終了コードは `scripts/auto_publish_diary.
 | worktree 内からの起動 / 親リポに未コミット変更 / `git switch main`・`pull` 失敗 / 同名ブランチ既存 / `git worktree add` 失敗 / `.env` 不整合 | environment | 以降スキップ |
 | `/write-hatena-diary` 失敗・生成記事 0 件（`finalize` に空パスが渡る） | write | publish 以降スキップ、worktree 残置 |
 | `publish_hatena.py` 失敗（HTTP 4xx/5xx・keyring 未登録等）/ 編集 URL 組み立て失敗 | publish | git 以降スキップ、worktree + 記事 md は残置（再投稿可能） |
-| フロントマター読取失敗 / `git commit`・`push` 失敗 / `gh pr create`・`merge` 失敗 | git | 後続スキップ、worktree 残置 |
-| `git worktree remove` 失敗（Windows ロック等） | (なし) | warning のみ。`status=ok` + `worktree_removed=false` で終了 |
+| フロントマター読取失敗 / `git commit`・`push` 失敗 / `gh pr create` 失敗 / `gh pr merge` 失敗かつリモート state ≠ `MERGED` | git | 後続スキップ、worktree 残置 |
+| `gh pr merge` exit 非 0 だがリモート state = `MERGED` | (なし) | warning のみ。Phase 4 へ継続（#219） |
+| `git worktree remove` 失敗（Windows ロック等） | (なし) | warning のみ。`status=ok` + `worktree_removed=false` + `worktree_remove_error` に stderr 要約を格納して終了 |
 | 外部コマンドのタイムアウト（120 秒超過） | 該当 Phase | error メッセージに「タイムアウト（120 秒）」を含めて識別可能にする |
 
 ## リカバリフロー
@@ -180,6 +168,11 @@ result.json への書き込みと終了コードは `scripts/auto_publish_diary.
 - 本スキルは **無人実行** が前提。`claude -p` 非対話モードでは `AskUserQuestion` がエラー扱いされるため発行しない
 - レビューでの修正適用は `/write-hatena-diary --auto-publish` 内の書き手自己判断に従う
 - PR は `gh pr merge --admin --squash` で即マージするため、ブランチ保護ルールがあっても通る。CI 実行は main へのマージ後（post-merge）に発生する想定
+- **Phase 3 merge の判定二段化**: `gh pr merge` の exit code が非 0 でも、続けて
+  `gh pr view <pr_number> --json state --jq .state` を 1 回呼び、`MERGED` が返れば成功扱いで
+  Phase 4 に進む。`MERGED` 以外（取得失敗・タイムアウト含む）は従来通り `failed_phase=git` で
+  停止する。リモートはマージ済みなのにローカル副作用で `gh pr merge` が非 0 を返すケース
+  （#219）の救済
 - **`gh pr merge --admin` 前提**: `gh auth status` で確認できる認証ユーザーが対象リポの Admin 権限を持つこと。becky3 個人リポではオーナー権限で満たすが、組織リポへ移行する場合は権限要件を再確認すること
 - 同日二重実行は Phase 0 でブランチ名重複エラー（`failed_phase=environment`）になる。Slack 側で「本日は既に投稿済み」と通知できる
 - **PR テンプレ配置の副作用**: `.github/PULL_REQUEST_TEMPLATE/auto-diary.md` は本スキル専用テンプレ。

--- a/scripts/auto_publish_diary.py
+++ b/scripts/auto_publish_diary.py
@@ -93,7 +93,12 @@ def fail(state: PublishState, *, failed_phase: str, error: str) -> None:
     sys.exit(1)
 
 
-def finish(state: PublishState, *, worktree_removed: bool) -> None:
+def finish(
+    state: PublishState,
+    *,
+    worktree_removed: bool,
+    worktree_remove_error: str | None = None,
+) -> None:
     """status=ok の result.json を書き出す（成功経路）。"""
     result = write_auto_publish_result.build_result(
         status="ok",
@@ -103,6 +108,7 @@ def finish(state: PublishState, *, worktree_removed: bool) -> None:
         pr_url=state.pr_url,
         worktree_removed=worktree_removed,
         worktree_path=state.worktree_path,
+        worktree_remove_error=worktree_remove_error,
     )
     try:
         write_auto_publish_result.write_result_file(state.parent_repo, result)
@@ -341,17 +347,40 @@ def cmd_finalize(article_path: str) -> int:
     except subprocess.TimeoutExpired:
         fail(state, failed_phase="git", error="gh pr merge がタイムアウト（120 秒）")
     if merge.returncode != 0:
-        fail(state, failed_phase="git", error=f"gh pr merge に失敗: {(merge.stderr or '').strip()}")
+        # ネットワーク一時失敗・将来的な `--delete-branch` 副作用等で「リモートはマージ済み
+        # なのに exit 非 0」となるケースを救うため、リモートの実 state を 1 回だけ確認する
+        # （#219）。
+        merge_stderr = _summarize_stderr(merge.stderr) or "(stderr 空)"
+        pr_state = _query_pr_state(pr_number, worktree_path)
+        if pr_state == "MERGED":
+            sys.stderr.write(
+                f"WARNING: gh pr merge exit {merge.returncode} / state=MERGED で継続: "
+                f"{merge_stderr}\n"
+            )
+        else:
+            state_detail = f" / state={pr_state}" if pr_state else " / state 取得失敗"
+            fail(
+                state,
+                failed_phase="git",
+                error=f"gh pr merge に失敗: {merge_stderr}{state_detail}",
+            )
 
     # --- Phase 4: worktree クリーンアップ（失敗しても status=ok）---
-    worktree_removed = cleanup(parent_repo, worktree_path, branch_name)
+    worktree_removed, worktree_remove_error = cleanup(parent_repo, worktree_path, branch_name)
 
     # --- Phase 5: 成功 result.json ---
-    finish(state, worktree_removed=worktree_removed)
+    finish(
+        state,
+        worktree_removed=worktree_removed,
+        worktree_remove_error=worktree_remove_error,
+    )
     if worktree_removed:
         print("✅ /auto-publish-diary 全工程成功")
     else:
-        print(f"✅ /auto-publish-diary 全工程成功（worktree 削除のみ失敗: {worktree_path}）")
+        detail = f" / stderr: {worktree_remove_error}" if worktree_remove_error else ""
+        print(
+            f"✅ /auto-publish-diary 全工程成功（worktree 削除のみ失敗: {worktree_path}{detail}）"
+        )
     return 0
 
 
@@ -384,23 +413,29 @@ def build_pr_body(
     return body
 
 
-def cleanup(parent_repo: str, worktree_path: str, branch_name: str) -> bool:
+def cleanup(
+    parent_repo: str, worktree_path: str, branch_name: str
+) -> tuple[bool, str | None]:
     """worktree 削除・ローカルブランチ削除・親リポ main 同期。
 
     前提: `gh pr merge --squash --admin` が成功した直後に限定して呼び出すこと。
     未マージブランチに対して呼ぶと `git branch -D` で未マージ変更が失われる。
 
     Returns:
-        worktree 削除に成功したか（Windows ロック等で失敗しても status=ok を保つため bool を返す）
+        (worktree 削除成否, 削除失敗時の stderr 1 行要約).
+        Windows ロック等で失敗しても status=ok を保つため bool で返す。失敗時の
+        stderr は #240 観測強化の一環として 1 行要約で返し、呼び出し元が
+        result.json に伝播させる。
     """
     # finalize は worktree を cwd として起動される。Windows では cwd が worktree 内に
     # ある間はディレクトリを削除できないため、remove 前に親リポへ chdir して cwd ロックを
     # 解放する（git 呼び出し自体は -C で repo を指定済み。chdir は OS の cwd ロック対策）。
     os.chdir(parent_repo)
-    removed = (
-        _run(["git", "-C", parent_repo, "worktree", "remove", "--force", worktree_path]).returncode
-        == 0
+    remove_proc = _run(
+        ["git", "-C", parent_repo, "worktree", "remove", "--force", worktree_path]
     )
+    removed = remove_proc.returncode == 0
+    remove_error = None if removed else _summarize_stderr(remove_proc.stderr)
     # squash マージ後は -d が「not fully merged」で失敗するため -D で強制削除する。
     # gh pr merge --admin --squash 成功直後に限定して呼ぶため安全。失敗は無視
     _run(["git", "-C", parent_repo, "branch", "-D", branch_name])
@@ -413,7 +448,40 @@ def cleanup(parent_repo: str, worktree_path: str, branch_name: str) -> bool:
         )
     except subprocess.TimeoutExpired:
         pass
-    return removed
+    return removed, remove_error
+
+
+def _query_pr_state(pr_number: str, cwd: str) -> str | None:
+    """`gh pr view <num> --json state --jq .state` を 1 回だけ呼んで state 文字列を返す。
+
+    マージ判定の正確性向上のため、`gh pr merge` の exit code が非 0 のときの保険として
+    リモート state を確認する用途（#219）。タイムアウト・取得失敗時は None を返す。
+
+    cwd は worktree パスを渡す前提（gh のリポジトリ自動検出を利用するため）。worktree が
+    壊れている等で gh 自身が exit 非 0 になった場合も None 返却で `fail()` 経路へ合流する。
+    """
+    try:
+        view = _run(
+            ["gh", "pr", "view", pr_number, "--json", "state", "--jq", ".state"],
+            cwd=cwd,
+            timeout=NETWORK_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if view.returncode != 0:
+        return None
+    return (view.stdout or "").strip() or None
+
+
+def _summarize_stderr(stderr: str | None) -> str | None:
+    """subprocess の stderr を result.json 用に 1 行要約にする。
+
+    複数行を半角空白で連結し、前後の空白を除去する。空文字は None に正規化する。
+    """
+    if not stderr:
+        return None
+    summary = " ".join(stderr.split())
+    return summary or None
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/write_auto_publish_result.py
+++ b/scripts/write_auto_publish_result.py
@@ -3,7 +3,7 @@
 呼び出し元（ai-assistant 等）が `claude -p` の出力経路差に依存せずファイル経由で
 成否・URL 等を取得できるよう、出力契約をレスポンスファイル方式に統一する。
 
-本スクリプトの出力契約定義および Phase ごとの呼び出し位置・引数組み合わせは
+出力契約（result.json スキーマ）の SSoT は本ファイルの `build_result()`。Phase ごとの呼び出し位置・引数組み合わせの運用文脈は
 `.claude/skills/auto-publish-diary/SKILL.md`「出力仕様」セクションを参照する。
 
 Usage（成功時、worktree 削除済み）:
@@ -19,7 +19,8 @@ Usage（成功時、worktree 削除失敗）:
     python scripts/write_auto_publish_result.py \\
         --parent-repo /path/to/parent --status ok \\
         --article-path ... --edit-url ... --public-url ... --pr-url ... \\
-        --worktree-removed false --worktree-path /abs/path/to/wt
+        --worktree-removed false --worktree-path /abs/path/to/wt \\
+        --worktree-remove-error "fatal: '/abs/path/to/wt' is not a working tree"
 
 Usage（失敗時）:
     python scripts/write_auto_publish_result.py \\
@@ -48,13 +49,33 @@ def build_result(
     pr_url: str | None = None,
     worktree_removed: bool = False,
     worktree_path: str | None = None,
+    worktree_remove_error: str | None = None,
     failed_phase: str | None = None,
     error: str | None = None,
 ) -> dict:
-    """result.json の中身（dict）を組み立てる.
+    """result.json の中身（dict）を組み立てる（出力スキーマの SSoT）.
 
     `auto_publish_diary.py`（orchestrator）と CLI の双方から呼ばれる共通ロジック。
     `status="ok"` のとき `worktree_removed=True` なら `worktree_path` は None に正規化する。
+
+    キー定義（status="ok" / "error" で共通スキーマ。値の意味は status で変わる）:
+
+    - status: "ok"（全 Phase 成功。`worktree_removed=false` の中間状態を含む）/ "error"（任意 Phase で停止）
+    - article_path: 生成記事の相対パス。生成前に失敗した場合は None
+    - edit_url: はてなブログの編集ページ URL（`https://blog.hatena.ne.jp/<ID>/<BLOG>/edit?entry=<id>`）。
+      下書き状態でも所有者がアクセスできる。投稿前に失敗した場合は None
+    - public_url: 公開記事 URL（`https://<BLOG>/entry/YYYY/MM/DD/000000`、記事日付ベースで算出。
+      公開されるまでは 404）。投稿前に失敗した場合は None
+    - pr_url: 作成された PR の URL。PR 作成前に失敗した場合は None
+    - merged: PR がリモートでマージ済みなら true（status="ok" なら必ず true、"error" なら必ず false）
+    - worktree_removed: cleanup で worktree が削除済みなら true。削除失敗時 / 失敗終了時は false
+    - worktree_path: 削除失敗時は残置 worktree の絶対パス。削除済みなら None。
+      worktree 作成前に失敗した場合は None
+    - worktree_remove_error: worktree 削除失敗時の `git worktree remove --force` stderr 1 行要約。
+      削除成功時 / status="error" 時は None（失敗そのものは `error` フィールドで報告される）
+    - failed_phase: status="error" のみ。失敗 Phase 名（`environment` / `write` / `publish` / `git`）。
+      `cleanup` は仕様上 status="ok" で終了するため現れない。status="ok" 時はキー自体が省略される
+    - error: status="error" のみのエラー要約 1 行。status="ok" 時はキー自体が省略される
     """
     if status == "ok":
         return {
@@ -66,6 +87,7 @@ def build_result(
             "merged": True,
             "worktree_removed": worktree_removed,
             "worktree_path": None if worktree_removed else worktree_path,
+            "worktree_remove_error": None if worktree_removed else worktree_remove_error,
         }
     return {
         "status": "error",
@@ -78,6 +100,7 @@ def build_result(
         "merged": False,
         "worktree_removed": False,
         "worktree_path": worktree_path,
+        "worktree_remove_error": None,
     }
 
 
@@ -139,6 +162,7 @@ def main() -> int:
     parser.add_argument("--pr-url", default=None)
     parser.add_argument("--worktree-removed", choices=["true", "false"], default=None)
     parser.add_argument("--worktree-path", default=None)
+    parser.add_argument("--worktree-remove-error", default=None)
     parser.add_argument("--failed-phase", default=None)
     parser.add_argument("--error", default=None)
     args = parser.parse_args()
@@ -156,6 +180,7 @@ def main() -> int:
         pr_url=args.pr_url,
         worktree_removed=args.worktree_removed == "true",
         worktree_path=args.worktree_path,
+        worktree_remove_error=args.worktree_remove_error,
         failed_phase=args.failed_phase,
         error=args.error,
     )

--- a/tests/test_auto_publish_diary.py
+++ b/tests/test_auto_publish_diary.py
@@ -124,6 +124,41 @@ class FailFinishTest(unittest.TestCase):
         data = self._read()
         self.assertEqual(data["worktree_removed"], False)
         self.assertEqual(data["worktree_path"], "D:/wt/x")
+        # 既定では remove_error は None
+        self.assertIsNone(data["worktree_remove_error"])
+
+    def test_finish_records_worktree_remove_error(self) -> None:
+        state = auto_publish_diary.PublishState(
+            parent_repo=self.parent_repo,
+            worktree_path="D:/wt/x",
+            article_path="a.md",
+            edit_url="https://e",
+            public_url="https://p",
+            pr_url="https://pr",
+        )
+        auto_publish_diary.finish(
+            state,
+            worktree_removed=False,
+            worktree_remove_error="fatal: 'D:/wt/x' is not a working tree",
+        )
+        data = self._read()
+        self.assertEqual(data["worktree_removed"], False)
+        self.assertEqual(
+            data["worktree_remove_error"], "fatal: 'D:/wt/x' is not a working tree"
+        )
+
+
+class SummarizeStderrTest(unittest.TestCase):
+    def test_returns_none_for_empty(self) -> None:
+        self.assertIsNone(auto_publish_diary._summarize_stderr(None))
+        self.assertIsNone(auto_publish_diary._summarize_stderr(""))
+        self.assertIsNone(auto_publish_diary._summarize_stderr("   \n\n  "))
+
+    def test_collapses_multiline_to_single_line(self) -> None:
+        self.assertEqual(
+            auto_publish_diary._summarize_stderr("line1\nline2\n   line3  "),
+            "line1 line2 line3",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_write_auto_publish_result.py
+++ b/tests/test_write_auto_publish_result.py
@@ -65,6 +65,7 @@ class WriteAutoPublishResultTest(unittest.TestCase):
             "merged": True,
             "worktree_removed": True,
             "worktree_path": None,
+            "worktree_remove_error": None,
         })
 
     def test_success_with_worktree_not_removed(self) -> None:
@@ -82,6 +83,25 @@ class WriteAutoPublishResultTest(unittest.TestCase):
         data = self._read_result()
         self.assertEqual(data["worktree_removed"], False)
         self.assertEqual(data["worktree_path"], "D:/GitHub/becky3/article-writer-wt-auto-20260520")
+        self.assertIsNone(data["worktree_remove_error"])
+
+    def test_success_with_worktree_remove_error_via_cli(self) -> None:
+        result = run_script([
+            "--parent-repo", str(self.parent_repo),
+            "--status", "ok",
+            "--article-path", "articles/hatena/2026-05-20-diary.md",
+            "--edit-url", "https://blog.hatena.ne.jp/ID/b/edit?entry=1",
+            "--public-url", "https://blog/entry/2026/05/20/000000",
+            "--pr-url", "https://github.com/becky3/article-writer/pull/101",
+            "--worktree-removed", "false",
+            "--worktree-path", "D:/wt/x",
+            "--worktree-remove-error", "fatal: 'D:/wt/x' is not a working tree",
+        ])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = self._read_result()
+        self.assertEqual(
+            data["worktree_remove_error"], "fatal: 'D:/wt/x' is not a working tree"
+        )
 
     def test_error_minimum_fields(self) -> None:
         result = run_script([
@@ -103,6 +123,7 @@ class WriteAutoPublishResultTest(unittest.TestCase):
             "merged": False,
             "worktree_removed": False,
             "worktree_path": None,
+            "worktree_remove_error": None,
         })
 
     def test_error_with_partial_progress(self) -> None:
@@ -242,6 +263,44 @@ class BuildResultFunctionTest(unittest.TestCase):
         self.assertEqual(result["merged"], True)
         self.assertEqual(result["worktree_removed"], True)
         self.assertIsNone(result["worktree_path"])
+
+    def test_build_result_ok_with_worktree_remove_error(self) -> None:
+        result = write_auto_publish_result.build_result(
+            status="ok",
+            article_path="a.md",
+            edit_url="https://e",
+            public_url="https://p",
+            pr_url="https://pr",
+            worktree_removed=False,
+            worktree_path="D:/wt/x",
+            worktree_remove_error="fatal: cannot remove 'D:/wt/x'",
+        )
+        self.assertEqual(result["worktree_removed"], False)
+        self.assertEqual(result["worktree_path"], "D:/wt/x")
+        self.assertEqual(result["worktree_remove_error"], "fatal: cannot remove 'D:/wt/x'")
+
+    def test_build_result_ok_normalizes_remove_error_when_removed(self) -> None:
+        # 削除成功時は worktree_remove_error を渡されても None に正規化される
+        result = write_auto_publish_result.build_result(
+            status="ok",
+            article_path="a.md",
+            edit_url="https://e",
+            public_url="https://p",
+            pr_url="https://pr",
+            worktree_removed=True,
+            worktree_remove_error="stale value",
+        )
+        self.assertIsNone(result["worktree_remove_error"])
+
+    def test_build_result_error_includes_remove_error_field_as_null(self) -> None:
+        # スキーマ均一化: error 時も worktree_remove_error キーは存在し None
+        result = write_auto_publish_result.build_result(
+            status="error",
+            failed_phase="publish",
+            error="HTTP 401",
+        )
+        self.assertIn("worktree_remove_error", result)
+        self.assertIsNone(result["worktree_remove_error"])
 
     def test_build_result_error_includes_partial_fields(self) -> None:
         result = write_auto_publish_result.build_result(


### PR DESCRIPTION
## Change type

- [x] fix

## Summary

- `/auto-publish-diary` の Phase 4 `cleanup()` で `git worktree remove --force` の stderr を捕捉し、result.json に `worktree_remove_error` フィールドを追加して失敗原因を観測可能にした（#240）
- `/auto-publish-diary` の Phase 3 で `gh pr merge` が exit 非 0 を返しても `gh pr view --json state` が `MERGED` なら継続する保険経路を追加し、誤検知による失敗扱いを回避（#219）
- `scripts/write_auto_publish_result.py` の `build_result()` を出力スキーマの SSoT として明示し、CLI に `--worktree-remove-error` 引数を追加して関数 API と CLI を完全整合
- SKILL.md の literal JSON 3 ブロック（drift 元）を削除し、フィールド表は「型・status 別出現条件」のみに縮退。各キーの Why は `build_result()` docstring に集約

## Test plan

- [x] 既存テスト + 新規追加分（build_result の worktree_remove_error 反映 / CLI 経由 / finish 経由 / _summarize_stderr 純関数）で `python -m unittest discover tests` を実行し 199/199 pass
- [x] markdownlint-cli2 / md-mermaid-lint / GitHub Mermaid 互換チェック 全て 0 件
- [x] code-reviewer / doc-reviewer エージェントレビュー実施済み（要修正対応・要相談は triage 経由でユーザー確認）

## Related issues

Closes #240
Closes #219