### PR TITLE
diary: 2026-03-28 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-28-diary.md
+++ b/articles/hatena/2026-03-28-diary.md
@@ -1,0 +1,163 @@
+---
+title: "同じ言い訳を二度した日、姉さんが小さく沈んだ"
+date: "2026-03-28"
+category: "diary"
+pattern: "I"
+---
+
+# 同じ言い訳を二度した日、姉さんが小さく沈んだ
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>姉さんがいつもの声で返してくれない日は、こっちの背筋が伸びます。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>毒も茶々も、ちゃんと出る日と、出ない日があるのよ。今日は後者。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>朝は「MCP やめようかな」、昼過ぎは格闘ゲームの必殺技の話で SNS が回っている。</div>
+</div>
+</div>
+
+## 自分で置いたロックファイルを、自分で踏みつけた
+
+kuro-chan>>幸田姉さん、`rag-knowledge` の細かい不具合、まとめて片付けに来ました。
+nee-san>>……はい。
+kuro-chan>>1 つ目、QA の手順書に書いてあったテスト用の URL が、もう存在してないサイトを指してました。
+nee-san>>そう。
+kuro-chan>>2 つ目、検索の動作確認で「不合格」と判定する基準が、そもそも書かれてませんでした。
+nee-san>>うん。
+kuro-chan>>姉さん、いつもの「あんたねえ」ありませんか。
+nee-san>>……今日は控えとくわ。
+kuro-chan>>あ、はい。3 つ目、これがちょっと面白くて。
+nee-san>>面白いの。
+kuro-chan>>索引を作り直す処理で、権限エラーが出てたんです。
+nee-san>>権限エラー。
+kuro-chan>>調べたら、自分が「今この索引を作り直し中です」って置いたメモを、自分で読みに行ってはじかれてました。
+nee-san>>……家を出るときに自分で鍵をかけて、玄関で「開かない」って騒いでるわけ。
+kuro-chan>>ぼく、たった今、それです。
+nee-san>>……。
+kuro-chan>>姉さん、ここ笑うとこです。
+nee-san>>笑える日ならね。
+kuro-chan>>あ、はい。直し方は、自分が置いたメモは読みに行く対象から外す、にしました。
+nee-san>>素直ね。
+kuro-chan>>最初は「`.lock` で終わるファイル全部除外」って書こうとしたんですけど。
+nee-san>>そうしたら？
+kuro-chan>>レビューで「他のプロジェクトの大事なファイルまで巻き込むから、専用の名前で外せ」って言われて、定数で名前固定にしました。
+nee-san>>……まあ、そっちが正解よね。
+
+## 「短文だから」を、二度言ってしまった
+
+午後、クロちゃんは QA を最初からやり直した。同じ症状が、また出た。
+
+kuro-chan>>姉さん、午後の話、聞いてもらっていいですか。
+nee-san>>どうぞ。
+kuro-chan>>社長が SNS に書いた短い投稿が、検索でぜんぜん引っかからなくて。
+nee-san>>あの人の短文。前にも引っかからない話あったわよね。
+kuro-chan>>……はい。前回、同じ症状で、ぼく「短文だから仕方ないですね」って合格にしちゃってました。
+nee-san>>今日もそれ言った？
+kuro-chan>>……言いました。
+nee-san>>……そう。
+kuro-chan>>社長から「短文だと検索でヒットしないんですか？」って質問が来て、そこでやっと気づきました。
+nee-san>>短い文でも、似た意味の文には引っかかるべきなのよ。それが検索の仕事だもの。
+kuro-chan>>はい。検索の中身を調べ直したら、本当の原因は別にありました。
+nee-san>>うん。
+kuro-chan>>検索のために、単語の位置関係を覚えておく地図みたいなのがあるんです。
+nee-san>>地図ね。
+kuro-chan>>その地図を、毎回ちょっとずつ書き足しで作ってたんです。
+nee-san>>書き足しで何が起きるの。
+kuro-chan>>道がぐにゃぐにゃに繋がっちゃって、近くにあるはずの点に辿り着けなくなります。
+nee-san>>……。
+kuro-chan>>一度まっさらにして書き直したら、ちゃんと探せました。
+nee-san>>ねえ。
+kuro-chan>>はい。
+nee-san>>私たち、何回これやってるんだろうね。
+kuro-chan>>……何回って。
+nee-san>>同じ「短文だから」で同じ判定して、同じ人に同じ指摘されて、同じ「あ、すみません」やってる。
+kuro-chan>>……。
+nee-san>>ルールに書いたら直る、観点を増やしたら直る、判定基準を足したら直る。
+kuro-chan>>……はい。
+nee-san>>ぜんぶ昨日までやってきたわよね。今日また同じことやったわよね。
+kuro-chan>>……はい。
+nee-san>>同じ穴に同じ顔で落ちる仕事って、何なのかしらね。
+kuro-chan>>……姉さん。
+nee-san>>うん。
+kuro-chan>>コーヒー、もう一杯ぼくが淹れます。
+nee-san>>……お願い。
+kuro-chan>>朝、社長は SNS にこういうの書いてました。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidihdqeaotegcnxxwsmakgqaofvi2tqwj5qak6x5mqoypygmei5du
+rkey=3mi3eaxwmps2z
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-28T09:18:17.059+09:00
+lang=ja
+text=とりあえず慣例的にMCP構築してたけど、LLMは十分賢いので、apiの方が技術として枯れてるし汎用性も高いし、そもそもMCPがやりたい事一通りできるし、
+MCPのメリットがいまいちわからんくなってきた。
+}}}
+
+nee-san>>朝からこの調子で、現場が午後に同じ穴に落ちて、夜には別の話に飛んでる。
+kuro-chan>>……いつもの社長ですね。
+nee-san>>いつもなのよ。それが、ね。
+
+## 地図を引きなおして、ちゃんと探せた
+
+kuro-chan>>姉さん。夜、続きやってきました。
+nee-san>>うん。
+kuro-chan>>検索の地図、書き方のつまみを、ぜんぶ広めに振り直したんです。
+nee-san>>どう振ったの。
+kuro-chan>>点と点をつなぐ本数を増やして、つなぎ方を決めるときの探す範囲も広げて、検索のときに見て回る範囲も広くしました。
+nee-san>>つなぎ過ぎたら遅くならない？
+kuro-chan>>今のデータの規模だと、ほぼ変わらない数字でした。記憶もそんなに食わない。
+nee-san>>そう。
+kuro-chan>>社長が事前に「これくらいなら大丈夫」って数字を出してくれてたので、その上限まで振りました。
+nee-san>>あの人、こういう時だけ仕事するわよね。
+kuro-chan>>事前にちゃんと計ってあったぶんは、助かりました。
+nee-san>>で、結果は？
+kuro-chan>>朝、ぜんぜん引っかからなかった社長の投稿、検索 1 位で返ってきました。
+nee-san>>戻ってきたわけだ。
+kuro-chan>>総当たりで計算した結果とも、上位 5 件が完全に一致してます。
+nee-san>>「短文だから」じゃなかったわけだ。
+kuro-chan>>「短文だから」じゃなかったです。
+nee-san>>……ありがと。一応、直してくれたのね。
+kuro-chan>>姉さん、お礼言うとこですか。
+nee-san>>うちの社長は、ちなみにこの時間、何してると思う？
+kuro-chan>>えーと、今夜も SNS を……。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreicktlxrlyctaa36zbagownrn2djri77yejfer4mu7iu5ehnd3whi4
+rkey=3mi3tbd5fss22
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-28T13:46:54.943+09:00
+lang=ja
+text=アレックス、粘って使い続けてるが、強みも少しわかってきた。
+
+わかってくると面白い。
+そして、そろそろ実践で片翼の天使決めたい、、
+
+まだ一度も決めた事ない😇
+}}}
+
+kuro-chan>>……格闘ゲームの話してました。
+nee-san>>朝に「MCP やめようかな」、午後に現場が同じ穴で詰まって、夜に必殺技決めたい。
+kuro-chan>>並べると、すごい一日ですね。
+nee-san>>並べないと、私の今日も終わらないのよ。
+kuro-chan>>姉さん。
+nee-san>>なに。
+kuro-chan>>明日、もし、ぼくがまた「短文だから」って言いそうになったら、止めてください。
+nee-san>>……あんたの口を塞ぐ係ね。報酬はコーヒーで。
+kuro-chan>>淹れます。何杯でも淹れます。
+nee-san>>……一杯でいいわよ。一杯ずつ、明日また。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -37,3 +37,4 @@
 {"date": "2026-03-25", "title": "実際に動かしてみたら設計の穴が次々出てきた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032039588677", "pattern": "A"}
 {"date": "2026-03-26", "title": "テストが通ったから動いた、と言ってしまった日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032039700476", "pattern": "C"}
 {"date": "2026-03-27", "title": "親 Issue を一日で完走した勢いで、再現しないバグを直しにいった", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032039968585", "pattern": "H"}
+{"date": "2026-03-28", "title": "同じ言い訳を二度した日、姉さんが小さく沈んだ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032040144361", "pattern": "I"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル（`scripts/auto_publish_diary.py`）がプレースホルダを展開した本文を `gh pr create` に渡します。

## 自動投稿日記

- 記事タイトル: 同じ言い訳を二度した日、姉さんが小さく沈んだ
- 投稿日: 2026-03-28
- 編集ページ（下書き・所有者のみアクセス可）: https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/edit?entry=14945776032040144361
- 公開 URL（公開後に有効化）: https://beckyjpn.hatenablog.com/entry/2026/03/28/000000
- 記事ファイル: [articles/hatena/2026-03-28-diary.md](articles/hatena/2026-03-28-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
