### PR TITLE
fix(auto-publish-diary): cleanup() の git worktree remove 失敗時に rmdir フォールバックを追加 (#245)

### DIFF
--- a/.claude/skills/auto-publish-diary/SKILL.md
+++ b/.claude/skills/auto-publish-diary/SKILL.md
@@ -154,7 +154,7 @@ result.json への書き込みと終了コードは `scripts/auto_publish_diary.
 | `publish_hatena.py` 失敗（HTTP 4xx/5xx・keyring 未登録等）/ 編集 URL 組み立て失敗 | publish | git 以降スキップ、worktree + 記事 md は残置（再投稿可能） |
 | フロントマター読取失敗 / `git commit`・`push` 失敗 / `gh pr create` 失敗 / `gh pr merge` 失敗かつリモート state ≠ `MERGED` | git | 後続スキップ、worktree 残置 |
 | `gh pr merge` exit 非 0 だがリモート state = `MERGED` | (なし) | warning のみ。Phase 4 へ継続（#219） |
-| `git worktree remove` 失敗（Windows ロック等） | (なし) | warning のみ。`status=ok` + `worktree_removed=false` + `worktree_remove_error` に stderr 要約を格納して終了 |
+| `git worktree remove` 失敗（Windows ロック等） | (なし) | warning のみ。空ディレクトリなら `os.rmdir` フォールバックで救済（#245）。フォールバック成功時は `status=ok` + `worktree_removed=true` + `worktree_remove_error` に元 stderr 要約を保持して終了（rmdir フォールバック発動シグナル）。フォールバックも失敗した場合は `status=ok` + `worktree_removed=false` + `worktree_remove_error` を格納して終了 |
 | 外部コマンドのタイムアウト（120 秒超過） | 該当 Phase | error メッセージに「タイムアウト（120 秒）」を含めて識別可能にする |
 
 ## リカバリフロー

--- a/scripts/auto_publish_diary.py
+++ b/scripts/auto_publish_diary.py
@@ -375,7 +375,12 @@ def cmd_finalize(article_path: str) -> int:
         worktree_remove_error=worktree_remove_error,
     )
     if worktree_removed:
-        print("✅ /auto-publish-diary 全工程成功")
+        if worktree_remove_error:
+            print(
+                f"✅ /auto-publish-diary 全工程成功（rmdir フォールバックで救済: {worktree_remove_error}）"
+            )
+        else:
+            print("✅ /auto-publish-diary 全工程成功")
     else:
         detail = f" / stderr: {worktree_remove_error}" if worktree_remove_error else ""
         print(
@@ -422,10 +427,13 @@ def cleanup(
     未マージブランチに対して呼ぶと `git branch -D` で未マージ変更が失われる。
 
     Returns:
-        (worktree 削除成否, 削除失敗時の stderr 1 行要約).
-        Windows ロック等で失敗しても status=ok を保つため bool で返す。失敗時の
-        stderr は #240 観測強化の一環として 1 行要約で返し、呼び出し元が
-        result.json に伝播させる。
+        (worktree 削除成否, `git worktree remove --force` の stderr 1 行要約).
+        Windows で `git worktree remove --force` が rmdir 段階だけ Permission denied
+        で失敗するケース（#245）に対し、ディレクトリが空であれば `os.rmdir` で
+        フォールバックする。フォールバックで削除に成功した場合は第 1 戻り値を True
+        にしつつ、第 2 戻り値には git の元 stderr を保持する（result.json で
+        `worktree_removed=true` + `worktree_remove_error` 非 null の組み合わせを
+        「rmdir フォールバック発動」のシグナルとして残し、根本原因の継続観測を可能にする）。
     """
     # finalize は worktree を cwd として起動される。Windows では cwd が worktree 内に
     # ある間はディレクトリを削除できないため、remove 前に親リポへ chdir して cwd ロックを
@@ -436,6 +444,13 @@ def cleanup(
     )
     removed = remove_proc.returncode == 0
     remove_error = None if removed else _summarize_stderr(remove_proc.stderr)
+    if not removed:
+        try:
+            if os.path.isdir(worktree_path) and not os.listdir(worktree_path):
+                os.rmdir(worktree_path)
+                removed = True
+        except OSError as exc:
+            sys.stderr.write(f"WARNING: rmdir fallback failed: {exc}\n")
     # squash マージ後は -d が「not fully merged」で失敗するため -D で強制削除する。
     # gh pr merge --admin --squash 成功直後に限定して呼ぶため安全。失敗は無視
     _run(["git", "-C", parent_repo, "branch", "-D", branch_name])

--- a/scripts/write_auto_publish_result.py
+++ b/scripts/write_auto_publish_result.py
@@ -71,8 +71,10 @@ def build_result(
     - worktree_removed: cleanup で worktree が削除済みなら true。削除失敗時 / 失敗終了時は false
     - worktree_path: 削除失敗時は残置 worktree の絶対パス。削除済みなら None。
       worktree 作成前に失敗した場合は None
-    - worktree_remove_error: worktree 削除失敗時の `git worktree remove --force` stderr 1 行要約。
-      削除成功時 / status="error" 時は None（失敗そのものは `error` フィールドで報告される）
+    - worktree_remove_error: `git worktree remove --force` の stderr 1 行要約。
+      - status="error" 時 / `git worktree remove` 自体が呼ばれなかった場合は None
+      - `git worktree remove` が失敗したとき（`os.rmdir` フォールバックの成否に関わらず）は元 stderr を保持する
+      - `worktree_removed=true` + `worktree_remove_error` 非 null は「rmdir フォールバックが効いて削除成功」を意味する（#245）
     - failed_phase: status="error" のみ。失敗 Phase 名（`environment` / `write` / `publish` / `git`）。
       `cleanup` は仕様上 status="ok" で終了するため現れない。status="ok" 時はキー自体が省略される
     - error: status="error" のみのエラー要約 1 行。status="ok" 時はキー自体が省略される
@@ -87,7 +89,7 @@ def build_result(
             "merged": True,
             "worktree_removed": worktree_removed,
             "worktree_path": None if worktree_removed else worktree_path,
-            "worktree_remove_error": None if worktree_removed else worktree_remove_error,
+            "worktree_remove_error": worktree_remove_error,
         }
     return {
         "status": "error",

--- a/tests/test_auto_publish_diary.py
+++ b/tests/test_auto_publish_diary.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 import json
 import pathlib
+import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 # scripts/ を import path に追加
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "scripts"))
@@ -146,6 +148,147 @@ class FailFinishTest(unittest.TestCase):
         self.assertEqual(
             data["worktree_remove_error"], "fatal: 'D:/wt/x' is not a working tree"
         )
+
+    def test_finish_keeps_remove_error_on_rmdir_fallback(self) -> None:
+        """rmdir フォールバック発動シグナル経路（#245）: removed=True でも stderr を保持する。"""
+        state = auto_publish_diary.PublishState(
+            parent_repo=self.parent_repo,
+            worktree_path="D:/wt/x",
+            article_path="a.md",
+            edit_url="https://e",
+            public_url="https://p",
+            pr_url="https://pr",
+        )
+        auto_publish_diary.finish(
+            state,
+            worktree_removed=True,
+            worktree_remove_error="error: failed to delete 'D:/wt/x': Permission denied",
+        )
+        data = self._read()
+        self.assertEqual(data["worktree_removed"], True)
+        self.assertEqual(
+            data["worktree_remove_error"],
+            "error: failed to delete 'D:/wt/x': Permission denied",
+        )
+        # 削除済みフラグ系は従前どおり None 化される
+        self.assertIsNone(data["worktree_path"])
+
+
+class CleanupTest(unittest.TestCase):
+    """`cleanup()` の戻り値分岐（#245 Windows rmdir フォールバック）を検証する。
+
+    本番事象（Windows での `git worktree remove --force` の rmdir 段階失敗）は CI Linux 環境で
+    再現できないため、subprocess / os 呼び出しを mock してフォールバック分岐の論理整合のみを担保する。
+    """
+
+    def _make_proc(
+        self, returncode: int, stderr: str = ""
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout="", stderr=stderr
+        )
+
+    def test_returns_true_when_git_remove_succeeds(self) -> None:
+        with (
+            mock.patch.object(auto_publish_diary, "_run") as run_mock,
+            mock.patch.object(auto_publish_diary.os, "chdir"),
+            mock.patch.object(auto_publish_diary.os, "listdir") as listdir_mock,
+            mock.patch.object(auto_publish_diary.os, "rmdir") as rmdir_mock,
+        ):
+            run_mock.side_effect = [self._make_proc(0), self._make_proc(0), self._make_proc(0)]
+            removed, error = auto_publish_diary.cleanup(
+                "/parent", "/parent/wt-x", "feature/x"
+            )
+        self.assertTrue(removed)
+        self.assertIsNone(error)
+        listdir_mock.assert_not_called()
+        rmdir_mock.assert_not_called()
+
+    def test_falls_back_to_rmdir_when_dir_is_empty(self) -> None:
+        with (
+            mock.patch.object(auto_publish_diary, "_run") as run_mock,
+            mock.patch.object(auto_publish_diary.os, "chdir"),
+            mock.patch.object(auto_publish_diary.os.path, "isdir", return_value=True),
+            mock.patch.object(auto_publish_diary.os, "listdir", return_value=[]) as listdir_mock,
+            mock.patch.object(auto_publish_diary.os, "rmdir") as rmdir_mock,
+        ):
+            run_mock.side_effect = [
+                self._make_proc(1, "error: failed to delete '/parent/wt-x': Permission denied"),
+                self._make_proc(0),
+                self._make_proc(0),
+            ]
+            removed, error = auto_publish_diary.cleanup(
+                "/parent", "/parent/wt-x", "feature/x"
+            )
+        self.assertTrue(removed)
+        self.assertEqual(
+            error, "error: failed to delete '/parent/wt-x': Permission denied"
+        )
+        listdir_mock.assert_called_once_with("/parent/wt-x")
+        rmdir_mock.assert_called_once_with("/parent/wt-x")
+        # rmdir フォールバック後も branch -D / pull --ff-only が従前通り呼ばれることを固定する
+        self.assertEqual(len(run_mock.call_args_list), 3)
+        self.assertEqual(
+            run_mock.call_args_list[0].args[0],
+            ["git", "-C", "/parent", "worktree", "remove", "--force", "/parent/wt-x"],
+        )
+        self.assertEqual(
+            run_mock.call_args_list[1].args[0],
+            ["git", "-C", "/parent", "branch", "-D", "feature/x"],
+        )
+        self.assertEqual(
+            run_mock.call_args_list[2].args[0],
+            ["git", "-C", "/parent", "pull", "--ff-only", "origin", "main"],
+        )
+
+    def test_returns_false_when_rmdir_raises_oserror(self) -> None:
+        """rmdir 自体が OSError を投げた場合（TOCTOU race 等）に silent 脱出することを確認。"""
+        with (
+            mock.patch.object(auto_publish_diary, "_run") as run_mock,
+            mock.patch.object(auto_publish_diary.os, "chdir"),
+            mock.patch.object(auto_publish_diary.os.path, "isdir", return_value=True),
+            mock.patch.object(auto_publish_diary.os, "listdir", return_value=[]),
+            mock.patch.object(
+                auto_publish_diary.os, "rmdir", side_effect=PermissionError("denied")
+            ) as rmdir_mock,
+        ):
+            run_mock.side_effect = [
+                self._make_proc(1, "error: failed to delete '/parent/wt-x': Permission denied"),
+                self._make_proc(0),
+                self._make_proc(0),
+            ]
+            removed, error = auto_publish_diary.cleanup(
+                "/parent", "/parent/wt-x", "feature/x"
+            )
+        self.assertFalse(removed)
+        self.assertEqual(
+            error, "error: failed to delete '/parent/wt-x': Permission denied"
+        )
+        rmdir_mock.assert_called_once_with("/parent/wt-x")
+
+    def test_returns_false_when_dir_not_empty(self) -> None:
+        with (
+            mock.patch.object(auto_publish_diary, "_run") as run_mock,
+            mock.patch.object(auto_publish_diary.os, "chdir"),
+            mock.patch.object(auto_publish_diary.os.path, "isdir", return_value=True),
+            mock.patch.object(
+                auto_publish_diary.os, "listdir", return_value=["stray.txt"]
+            ),
+            mock.patch.object(auto_publish_diary.os, "rmdir") as rmdir_mock,
+        ):
+            run_mock.side_effect = [
+                self._make_proc(1, "error: failed to delete '/parent/wt-x': Permission denied"),
+                self._make_proc(0),
+                self._make_proc(0),
+            ]
+            removed, error = auto_publish_diary.cleanup(
+                "/parent", "/parent/wt-x", "feature/x"
+            )
+        self.assertFalse(removed)
+        self.assertEqual(
+            error, "error: failed to delete '/parent/wt-x': Permission denied"
+        )
+        rmdir_mock.assert_not_called()
 
 
 class SummarizeStderrTest(unittest.TestCase):


### PR DESCRIPTION
## Change type

- [x] fix（バグ修正）

## Summary

- `cleanup()` 内で `git worktree remove --force` が失敗したとき、空ディレクトリなら `os.rmdir` でフォールバックして worktree 削除を完遂する（Windows で rmdir 段階だけ Permission denied になる事象 #245 の救済）。`isdir`/`listdir`/`rmdir` を 1 つの try で OSError 捕捉して TOCTOU race を回避。フォールバック失敗時は `WARNING: rmdir fallback failed: ...` で stderr に記録
- `build_result()` の `worktree_remove_error` 正規化を解除。`worktree_removed=true` + `worktree_remove_error` 非 null の組み合わせを「rmdir フォールバック発動」のシグナルとして result.json に残し、根本原因の継続観測を可能にする
- finalize の最終 print 文をフォールバック発動時に専用メッセージ「rmdir フォールバックで救済: ...」を出すよう更新（コンソールでも即座に識別可能）
- `.claude/skills/auto-publish-diary/SKILL.md` 行 157 の cleanup エラー表に rmdir フォールバック分岐を追記
- テスト追加: `CleanupTest` 4 シナリオ（git remove 成功 / フォールバック成功 / rmdir OSError / 非空 dir）+ `_run.call_args_list` 引数 assert（branch -D / pull --ff-only 経路固定）+ `finish()` のフォールバック発動シグナル経路テスト

## Test plan

- [x] `python -m unittest tests.test_auto_publish_diary` 全 13 件成功
- [x] code-reviewer / doc-reviewer による Phase 2 レビュー実施・指摘対応完了

## Related issues

Closes #245