### PR TITLE
fix(auto-publish-diary): cleanup() の rmdir フォールバックをリトライ + バックオフへ変更 (#245)

### DIFF
--- a/scripts/auto_publish_diary.py
+++ b/scripts/auto_publish_diary.py
@@ -26,6 +26,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -36,6 +37,14 @@ import write_auto_publish_result
 NETWORK_TIMEOUT = 120
 # 非対話・接続タイムアウトを強制する SSH オプション（パスフレーズ待ち等のハングを防ぐ）
 GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=30"
+# ハードリミット: rmdir フォールバックの試行回数上限。Windows の Permission denied は
+# git remove 直後から数秒間持続するため複数回の再試行が必要（#245 / PR #247 観測）。
+# 上限を解除可能にすると無限ループのリスクがあるため定数固定とする
+MAX_RMDIR_RETRY = 5
+# rmdir リトライ間のバックオフ刻み（秒）。試行 i のディレイは `(i + 1) * RMDIR_BACKOFF_STEP`。
+# 5 回試行で合計 7.5 秒（0.5+1.0+1.5+2.0+2.5）の待機となり、観測された Windows
+# ロックの解放時間内に収まる範囲
+RMDIR_BACKOFF_STEP = 0.5
 
 
 @dataclass
@@ -429,11 +438,14 @@ def cleanup(
     Returns:
         (worktree 削除成否, `git worktree remove --force` の stderr 1 行要約).
         Windows で `git worktree remove --force` が rmdir 段階だけ Permission denied
-        で失敗するケース（#245）に対し、ディレクトリが空であれば `os.rmdir` で
-        フォールバックする。フォールバックで削除に成功した場合は第 1 戻り値を True
-        にしつつ、第 2 戻り値には git の元 stderr を保持する（result.json で
-        `worktree_removed=true` + `worktree_remove_error` 非 null の組み合わせを
-        「rmdir フォールバック発動」のシグナルとして残し、根本原因の継続観測を可能にする）。
+        で失敗するケース（#245）に対し、ディレクトリが空であれば `os.rmdir` の
+        リトライ + バックオフでフォールバックする。Permission denied は git remove
+        直後から数秒間持続するため、単発の rmdir では救済できず複数回の再試行が
+        必要（PR #246 で単発フォールバックを入れたが PR #247 で再失敗を観測）。
+        フォールバックで削除に成功した場合は第 1 戻り値を True にしつつ、第 2 戻り値
+        には git の元 stderr を保持する（result.json で `worktree_removed=true`
+        + `worktree_remove_error` 非 null の組み合わせを「rmdir フォールバック発動」
+        のシグナルとして残し、根本原因の継続観測を可能にする）。
     """
     # finalize は worktree を cwd として起動される。Windows では cwd が worktree 内に
     # ある間はディレクトリを削除できないため、remove 前に親リポへ chdir して cwd ロックを
@@ -445,12 +457,23 @@ def cleanup(
     removed = remove_proc.returncode == 0
     remove_error = None if removed else _summarize_stderr(remove_proc.stderr)
     if not removed:
-        try:
-            if os.path.isdir(worktree_path) and not os.listdir(worktree_path):
+        last_exc: OSError | None = None
+        for attempt in range(MAX_RMDIR_RETRY):
+            try:
+                if not (os.path.isdir(worktree_path) and not os.listdir(worktree_path)):
+                    # ディレクトリ不在 or 非空ならフォールバック対象外。以降の再試行も無意味
+                    break
                 os.rmdir(worktree_path)
                 removed = True
-        except OSError as exc:
-            sys.stderr.write(f"WARNING: rmdir fallback failed: {exc}\n")
+                break
+            except OSError as exc:
+                last_exc = exc
+                if attempt < MAX_RMDIR_RETRY - 1:
+                    time.sleep((attempt + 1) * RMDIR_BACKOFF_STEP)
+        if not removed and last_exc is not None:
+            sys.stderr.write(
+                f"WARNING: rmdir fallback failed after {MAX_RMDIR_RETRY} retries: {last_exc}\n"
+            )
     # squash マージ後は -d が「not fully merged」で失敗するため -D で強制削除する。
     # gh pr merge --admin --squash 成功直後に限定して呼ぶため安全。失敗は無視
     _run(["git", "-C", parent_repo, "branch", "-D", branch_name])

--- a/scripts/auto_publish_diary.py
+++ b/scripts/auto_publish_diary.py
@@ -37,13 +37,14 @@ import write_auto_publish_result
 NETWORK_TIMEOUT = 120
 # 非対話・接続タイムアウトを強制する SSH オプション（パスフレーズ待ち等のハングを防ぐ）
 GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=30"
-# ハードリミット: rmdir フォールバックの試行回数上限。Windows の Permission denied は
-# git remove 直後から数秒間持続するため複数回の再試行が必要（#245 / PR #247 観測）。
-# 上限を解除可能にすると無限ループのリスクがあるため定数固定とする
-MAX_RMDIR_RETRY = 5
-# rmdir リトライ間のバックオフ刻み（秒）。試行 i のディレイは `(i + 1) * RMDIR_BACKOFF_STEP`。
-# 5 回試行で合計 7.5 秒（0.5+1.0+1.5+2.0+2.5）の待機となり、観測された Windows
-# ロックの解放時間内に収まる範囲
+# ハードリミット: rmdir フォールバックの総試行回数（initial + retries の合計）。
+# Windows の Permission denied は git remove 直後から数秒間持続するため複数回の再試行が
+# 必要（#245 / PR #247 観測）。上限を解除可能にすると無限ループのリスクがあるため定数固定とする
+MAX_RMDIR_ATTEMPTS = 6
+# rmdir リトライ間のバックオフ刻み（秒）。試行 i（0 始まり）の失敗後ディレイは
+# `(i + 1) * RMDIR_BACKOFF_STEP`。最終試行（i = MAX_RMDIR_ATTEMPTS - 1）後は sleep しない。
+# 6 試行 = 5 sleep（0.5+1.0+1.5+2.0+2.5）= 合計 7.5 秒の待機となり、観測された
+# Windows ロックの解放時間内に収まる範囲
 RMDIR_BACKOFF_STEP = 0.5
 
 
@@ -458,7 +459,7 @@ def cleanup(
     remove_error = None if removed else _summarize_stderr(remove_proc.stderr)
     if not removed:
         last_exc: OSError | None = None
-        for attempt in range(MAX_RMDIR_RETRY):
+        for attempt in range(MAX_RMDIR_ATTEMPTS):
             try:
                 if not (os.path.isdir(worktree_path) and not os.listdir(worktree_path)):
                     # ディレクトリ不在 or 非空ならフォールバック対象外。以降の再試行も無意味
@@ -468,11 +469,11 @@ def cleanup(
                 break
             except OSError as exc:
                 last_exc = exc
-                if attempt < MAX_RMDIR_RETRY - 1:
+                if attempt < MAX_RMDIR_ATTEMPTS - 1:
                     time.sleep((attempt + 1) * RMDIR_BACKOFF_STEP)
         if not removed and last_exc is not None:
             sys.stderr.write(
-                f"WARNING: rmdir fallback failed after {MAX_RMDIR_RETRY} retries: {last_exc}\n"
+                f"WARNING: rmdir fallback failed after {MAX_RMDIR_ATTEMPTS} attempts: {last_exc}\n"
             )
     # squash マージ後は -d が「not fully merged」で失敗するため -D で強制削除する。
     # gh pr merge --admin --squash 成功直後に限定して呼ぶため安全。失敗は無視

--- a/tests/test_auto_publish_diary.py
+++ b/tests/test_auto_publish_diary.py
@@ -194,6 +194,7 @@ class CleanupTest(unittest.TestCase):
             mock.patch.object(auto_publish_diary.os, "chdir"),
             mock.patch.object(auto_publish_diary.os, "listdir") as listdir_mock,
             mock.patch.object(auto_publish_diary.os, "rmdir") as rmdir_mock,
+            mock.patch.object(auto_publish_diary.time, "sleep") as sleep_mock,
         ):
             run_mock.side_effect = [self._make_proc(0), self._make_proc(0), self._make_proc(0)]
             removed, error = auto_publish_diary.cleanup(
@@ -203,6 +204,8 @@ class CleanupTest(unittest.TestCase):
         self.assertIsNone(error)
         listdir_mock.assert_not_called()
         rmdir_mock.assert_not_called()
+        # git remove 成功経路ではフォールバックも sleep も発生しないことを固定
+        sleep_mock.assert_not_called()
 
     def test_falls_back_to_rmdir_when_dir_is_empty(self) -> None:
         with (
@@ -211,6 +214,7 @@ class CleanupTest(unittest.TestCase):
             mock.patch.object(auto_publish_diary.os.path, "isdir", return_value=True),
             mock.patch.object(auto_publish_diary.os, "listdir", return_value=[]) as listdir_mock,
             mock.patch.object(auto_publish_diary.os, "rmdir") as rmdir_mock,
+            mock.patch.object(auto_publish_diary.time, "sleep") as sleep_mock,
         ):
             run_mock.side_effect = [
                 self._make_proc(1, "error: failed to delete '/parent/wt-x': Permission denied"),
@@ -226,6 +230,8 @@ class CleanupTest(unittest.TestCase):
         )
         listdir_mock.assert_called_once_with("/parent/wt-x")
         rmdir_mock.assert_called_once_with("/parent/wt-x")
+        # 初回試行で成功する経路では sleep を呼ばないことを固定（不要な待機を避ける）
+        sleep_mock.assert_not_called()
         # rmdir フォールバック後も branch -D / pull --ff-only が従前通り呼ばれることを固定する
         self.assertEqual(len(run_mock.call_args_list), 3)
         self.assertEqual(
@@ -241,8 +247,12 @@ class CleanupTest(unittest.TestCase):
             ["git", "-C", "/parent", "pull", "--ff-only", "origin", "main"],
         )
 
-    def test_returns_false_when_rmdir_raises_oserror(self) -> None:
-        """rmdir 自体が OSError を投げた場合（TOCTOU race 等）に silent 脱出することを確認。"""
+    def test_returns_false_when_rmdir_raises_oserror_after_all_retries(self) -> None:
+        """rmdir が上限まで連続 OSError を投げた場合に最終的に諦め silent 脱出することを確認。
+
+        PR #246 の単発フォールバックでは PR #247 で再失敗を観測したため、リトライ + バックオフへ
+        変更（#245 追加対応）。本テストは上限回数まで連続失敗するシナリオを担保する。
+        """
         with (
             mock.patch.object(auto_publish_diary, "_run") as run_mock,
             mock.patch.object(auto_publish_diary.os, "chdir"),
@@ -251,6 +261,7 @@ class CleanupTest(unittest.TestCase):
             mock.patch.object(
                 auto_publish_diary.os, "rmdir", side_effect=PermissionError("denied")
             ) as rmdir_mock,
+            mock.patch.object(auto_publish_diary.time, "sleep") as sleep_mock,
         ):
             run_mock.side_effect = [
                 self._make_proc(1, "error: failed to delete '/parent/wt-x': Permission denied"),
@@ -264,7 +275,53 @@ class CleanupTest(unittest.TestCase):
         self.assertEqual(
             error, "error: failed to delete '/parent/wt-x': Permission denied"
         )
-        rmdir_mock.assert_called_once_with("/parent/wt-x")
+        self.assertEqual(rmdir_mock.call_count, auto_publish_diary.MAX_RMDIR_RETRY)
+        # バックオフ間隔: 試行 i のディレイは (i + 1) * RMDIR_BACKOFF_STEP。
+        # 最終試行（i = MAX_RMDIR_RETRY - 1）後は sleep しないため呼び出し回数は MAX_RMDIR_RETRY - 1
+        expected_sleeps = [
+            mock.call((i + 1) * auto_publish_diary.RMDIR_BACKOFF_STEP)
+            for i in range(auto_publish_diary.MAX_RMDIR_RETRY - 1)
+        ]
+        self.assertEqual(sleep_mock.call_args_list, expected_sleeps)
+
+    def test_succeeds_when_rmdir_recovers_after_retries(self) -> None:
+        """rmdir が数回 OSError → 最終的に成功するシナリオでリトライが正しく機能することを確認。
+
+        Windows の Permission denied が数秒間持続する観察（PR #247）に対する救済経路。
+        """
+        # 2 回失敗後に成功するシナリオ（合計 3 回呼び出し、間に 2 回 sleep）
+        with (
+            mock.patch.object(auto_publish_diary, "_run") as run_mock,
+            mock.patch.object(auto_publish_diary.os, "chdir"),
+            mock.patch.object(auto_publish_diary.os.path, "isdir", return_value=True),
+            mock.patch.object(auto_publish_diary.os, "listdir", return_value=[]),
+            mock.patch.object(
+                auto_publish_diary.os,
+                "rmdir",
+                side_effect=[PermissionError("denied"), PermissionError("denied"), None],
+            ) as rmdir_mock,
+            mock.patch.object(auto_publish_diary.time, "sleep") as sleep_mock,
+        ):
+            run_mock.side_effect = [
+                self._make_proc(1, "error: failed to delete '/parent/wt-x': Permission denied"),
+                self._make_proc(0),
+                self._make_proc(0),
+            ]
+            removed, error = auto_publish_diary.cleanup(
+                "/parent", "/parent/wt-x", "feature/x"
+            )
+        self.assertTrue(removed)
+        # remove_error は git の元 stderr を保持（フォールバック発動シグナル）
+        self.assertEqual(
+            error, "error: failed to delete '/parent/wt-x': Permission denied"
+        )
+        self.assertEqual(rmdir_mock.call_count, 3)
+        # 失敗 2 回の間に sleep 2 回（成功した 3 回目の後は sleep しない）
+        expected_sleeps = [
+            mock.call(1 * auto_publish_diary.RMDIR_BACKOFF_STEP),
+            mock.call(2 * auto_publish_diary.RMDIR_BACKOFF_STEP),
+        ]
+        self.assertEqual(sleep_mock.call_args_list, expected_sleeps)
 
     def test_returns_false_when_dir_not_empty(self) -> None:
         with (
@@ -275,6 +332,7 @@ class CleanupTest(unittest.TestCase):
                 auto_publish_diary.os, "listdir", return_value=["stray.txt"]
             ),
             mock.patch.object(auto_publish_diary.os, "rmdir") as rmdir_mock,
+            mock.patch.object(auto_publish_diary.time, "sleep") as sleep_mock,
         ):
             run_mock.side_effect = [
                 self._make_proc(1, "error: failed to delete '/parent/wt-x': Permission denied"),
@@ -289,6 +347,8 @@ class CleanupTest(unittest.TestCase):
             error, "error: failed to delete '/parent/wt-x': Permission denied"
         )
         rmdir_mock.assert_not_called()
+        # 非空 dir 経路では初回 iteration で break するため sleep も発生しないことを固定
+        sleep_mock.assert_not_called()
 
 
 class SummarizeStderrTest(unittest.TestCase):

--- a/tests/test_auto_publish_diary.py
+++ b/tests/test_auto_publish_diary.py
@@ -275,12 +275,12 @@ class CleanupTest(unittest.TestCase):
         self.assertEqual(
             error, "error: failed to delete '/parent/wt-x': Permission denied"
         )
-        self.assertEqual(rmdir_mock.call_count, auto_publish_diary.MAX_RMDIR_RETRY)
+        self.assertEqual(rmdir_mock.call_count, auto_publish_diary.MAX_RMDIR_ATTEMPTS)
         # バックオフ間隔: 試行 i のディレイは (i + 1) * RMDIR_BACKOFF_STEP。
-        # 最終試行（i = MAX_RMDIR_RETRY - 1）後は sleep しないため呼び出し回数は MAX_RMDIR_RETRY - 1
+        # 最終試行（i = MAX_RMDIR_ATTEMPTS - 1）後は sleep しないため呼び出し回数は MAX_RMDIR_ATTEMPTS - 1
         expected_sleeps = [
             mock.call((i + 1) * auto_publish_diary.RMDIR_BACKOFF_STEP)
-            for i in range(auto_publish_diary.MAX_RMDIR_RETRY - 1)
+            for i in range(auto_publish_diary.MAX_RMDIR_ATTEMPTS - 1)
         ]
         self.assertEqual(sleep_mock.call_args_list, expected_sleeps)
 

--- a/tests/test_write_auto_publish_result.py
+++ b/tests/test_write_auto_publish_result.py
@@ -279,8 +279,13 @@ class BuildResultFunctionTest(unittest.TestCase):
         self.assertEqual(result["worktree_path"], "D:/wt/x")
         self.assertEqual(result["worktree_remove_error"], "fatal: cannot remove 'D:/wt/x'")
 
-    def test_build_result_ok_normalizes_remove_error_when_removed(self) -> None:
-        # 削除成功時は worktree_remove_error を渡されても None に正規化される
+    def test_build_result_ok_preserves_remove_error_when_removed(self) -> None:
+        """rmdir フォールバック発動シグナル経路（#245）.
+
+        worktree_removed=True かつ worktree_remove_error 非 null の組み合わせは
+        「git remove は失敗したが rmdir フォールバックで救済された」ことを表すシグナル。
+        正規化（None 化）してしまうと根本原因の継続観測ができなくなるため、ここで保持する。
+        """
         result = write_auto_publish_result.build_result(
             status="ok",
             article_path="a.md",
@@ -288,9 +293,14 @@ class BuildResultFunctionTest(unittest.TestCase):
             public_url="https://p",
             pr_url="https://pr",
             worktree_removed=True,
-            worktree_remove_error="stale value",
+            worktree_remove_error="error: failed to delete '/wt/x': Permission denied",
         )
-        self.assertIsNone(result["worktree_remove_error"])
+        self.assertEqual(
+            result["worktree_remove_error"],
+            "error: failed to delete '/wt/x': Permission denied",
+        )
+        # 成功時は worktree_path は None に正規化される（既存仕様）
+        self.assertIsNone(result["worktree_path"])
 
     def test_build_result_error_includes_remove_error_field_as_null(self) -> None:
         # スキーマ均一化: error 時も worktree_remove_error キーは存在し None


### PR DESCRIPTION
## Change type

- [x] fix（バグ修正）

## Summary

- PR #246 で導入した単発 `os.rmdir` フォールバックでは PR #247（2026-06-08 自動投稿）で再失敗を観測。Windows の Permission denied は `git worktree remove --force` 直後から数秒間持続するため、単発 rmdir では救済できないことが判明
- `cleanup()` のフォールバックを `MAX_RMDIR_RETRY=5` 回のリトライ + `RMDIR_BACKOFF_STEP=0.5` の線形バックオフへ変更（合計 7.5s の待機）
- ハードリミット定数 `MAX_RMDIR_RETRY` / `RMDIR_BACKOFF_STEP` をモジュールトップレベルに追加（`# ハードリミット:` コメント付与）
- リトライ全失敗時の WARNING に試行回数を明示
- 既存テストを「複数回試行」前提に拡張し、数回失敗 → 最終的に成功 / 上限まで失敗の両シナリオを追加
- 既存防御テスト 2 件に `time.sleep` mock + `assert_not_called` を追加（code-reviewer の Suggestion 反映）
- 関連クリーンアップ: PR #246 で `build_result()` の `worktree_remove_error` 正規化を解除した変更と矛盾していた旧テスト `test_build_result_ok_normalizes_remove_error_when_removed` を新仕様に合わせて書き換え

## Test plan

- [x] 既存テスト 205 件 + 新規追加分すべて pass
- [x] ruff clean
- [x] markdownlint 0 errors
- [ ] 手動 QA: 次回 `/auto-publish-diary` 実行で `.tmp/auto-publish-diary/result.json` の `worktree_removed=true` を確認（リトライ救済 or rmdir 不要のいずれか）

## Related issues

Closes #245

関連 PR:
- #246: 単発フォールバック導入（マージ済み）
- #247: 単発フォールバックでも再失敗を観測した直近の自動投稿 PR