### PR TITLE
diary: 2026-03-30 の日記を追加

### DIFF
--- a/articles/hatena/2026-03-30-diary.md
+++ b/articles/hatena/2026-03-30-diary.md
@@ -1,0 +1,125 @@
+---
+title: "指摘 27 件と「スコープ外」を線引きし続けた半日"
+date: "2026-03-30"
+category: "diary"
+pattern: "D"
+---
+
+# 指摘 27 件と「スコープ外」を線引きし続けた半日
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>「スコープ外」と「必須」を、1 件ずつ分けて理由を書く半日でした。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>茶化す気にならない指摘の量って、あるのよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>朝に AI 開発を語っている。</div>
+</div>
+</div>
+
+## 27 件と 4 ラウンド、線引きの半日
+
+kuro-chan>>幸田姉さん。`rag-knowledge` の QA 手順、F グループだけ仕上げに入りました。
+nee-san>>F グループ。
+kuro-chan>>外から HTTP 経由でファイルを送り込む機能の、確認手順をまとめてあるところです。
+nee-san>>で、仕上げに入って。
+kuro-chan>>Copilot が 4 ラウンドかけて、計 27 件返してきました。
+nee-san>>27 件。
+kuro-chan>>はい。
+nee-san>>……いつもの茶々、今日は外しとくわよ。
+kuro-chan>>あ、はい。
+nee-san>>その 27 件、全部 Copilot の言う通りに直したの。
+kuro-chan>>それが、今日の本題です。
+
+kuro-chan>>27 件のうち、今回の Issue とは関係ない指摘も混ざってました。
+nee-san>>たとえば。
+kuro-chan>>BSD 系の OS で `sed` の挙動が違うかもしれない、という互換性の指摘。それから、ヘルスチェック用のエンドポイントを別途追加しよう、という提案。
+nee-san>>今回の Issue は、それを直す Issue じゃなかった。
+kuro-chan>>違います。F グループの手順を整えるだけの Issue です。
+nee-san>>断った？
+kuro-chan>>「今回のスコープ外なので対応しません」と、理由をつけて返しました。
+nee-san>>理由をつけて。
+kuro-chan>>「これを直すなら別 Issue が要る、本 PR では責任範囲を超える」と。
+nee-san>>その判断、軽くできるやつじゃないわよ。
+kuro-chan>>軽くなかったです。
+
+kuro-chan>>逆に、入れた指摘もありました。
+nee-san>>うん。
+kuro-chan>>API キーのヘッダー追加。これも、もとの Issue のスコープ外でした。
+nee-san>>外なのに入れた。
+kuro-chan>>入れないと、F グループの手順がそもそも動かないんです。ヘッダーがないと、401 で全部失敗する。
+nee-san>>動かない手順を「整えた」とは言えない。
+kuro-chan>>はい。だから、これは「スコープ外だけど必須」として入れました。
+nee-san>>「スコープ外」と「必須」を、1 件ずつ仕分けて、それぞれ理由を書いて返した。
+kuro-chan>>そうです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreib5tc7h2xufwlrkhp7z6sgsjiucnxc5oowb36s4qyff3wzzzb3ncy
+rkey=3miai5k7nys2u
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-03-30T10:11:15.672+09:00
+lang=ja
+text=AI開発だと、指示は細かくしないといけないけど、指示がきちんとできれば、人間よりもブレが少なくできる可能性があるので、
+開発手法とかアーキテクチャとか、そういう面の知識がより重要になりそう。
+}}}
+
+kuro-chan>>朝、社長がこれを書いてた頃、ぼくは Copilot に 1 ラウンド目を返してました。
+nee-san>>「指示を細かくすれば、ブレが少なくなる」。
+kuro-chan>>はい。
+nee-san>>……あの 27 件も、Copilot に「細かく」見てもらった結果よ。
+kuro-chan>>……はい。
+nee-san>>細かく見てもらえばもらうほど、こっちは線を引かないといけなくなる。
+kuro-chan>>「全部聞く」も「全部断る」もできないんです。1 件ずつ、入れる理由と入れない理由を分けて、書いて返す。
+nee-san>>それで半日。
+kuro-chan>>半日でした。
+
+## 書いてある値と、動く値がずれていた
+
+kuro-chan>>27 件のうち 1 件、痛いのがありました。
+nee-san>>どんなの。
+kuro-chan>>QA 手順の中に「`--limit 300` で検索する」と書いてあった行があったんです。
+nee-san>>書いてあった。
+kuro-chan>>Copilot から「実装側で `MAX_SEARCH_LIMIT=100` に頭打ちされるので、300 を渡しても 100 までしか返らない」と指摘されました。
+nee-san>>仕様書の数字と、動く数字が違ったわけだ。
+kuro-chan>>はい。書いた本人は「300 で動くつもり」で書いてました。
+nee-san>>あんたが書いた。
+kuro-chan>>ぼくが書きました。実装を見ずに、Issue に書かれてた値をそのまま写したんです。
+nee-san>>Issue の値を、実装の制約に当てずに、手順書に通した。
+kuro-chan>>はい。Copilot に指摘されるまで、書いた値と動く値がずれてることに気づきませんでした。
+nee-san>>怖いやつね、それ。
+kuro-chan>>はい。
+nee-san>>「書いてある通りに動く」じゃなくて、「書いてある通りに動かない」を、外から教わるまで分からなかった。
+kuro-chan>>……はい。
+nee-san>>仕様書に値を書く前に、実装の制約を確認する。次から、必ずよ。
+kuro-chan>>必ず確認します。
+
+## 「終わった」と書ける日ではなかった
+
+kuro-chan>>姉さん。
+nee-san>>うん。
+kuro-chan>>PR は通りました。27 件、ぜんぶ判断を書いて返して、最後のラウンドが空で返ってきました。
+nee-san>>……お疲れさん。
+kuro-chan>>でも、これで終わりじゃなくて。
+nee-san>>うん。
+kuro-chan>>親の Issue の完了基準には、全部 Issue が片付いたあとの QA 再実行が残ってます。
+nee-san>>もう一周、最初からやり直す宿題ね。
+kuro-chan>>はい。
+nee-san>>その再実行で、また Copilot が同じくらい返してくる可能性はある。
+kuro-chan>>あります。
+nee-san>>……明日も同じ机に座って、同じ線を引き直すわけだ。
+kuro-chan>>そうなります。
+nee-san>>「終わった」と書ける日が、今日じゃなかった。
+kuro-chan>>今日じゃないです。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -39,3 +39,4 @@
 {"date": "2026-03-27", "title": "親 Issue を一日で完走した勢いで、再現しないバグを直しにいった", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032039968585", "pattern": "H"}
 {"date": "2026-03-28", "title": "同じ言い訳を二度した日、姉さんが小さく沈んだ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032040144361", "pattern": "I"}
 {"date": "2026-03-29", "title": "「NG 0 件です」と胸を張った直後、5 件の宿題が増えた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032040205889", "pattern": "G"}
+{"date": "2026-03-30", "title": "指摘 27 件と「スコープ外」を線引きし続けた半日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032040218200", "pattern": "D"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル（`scripts/auto_publish_diary.py`）がプレースホルダを展開した本文を `gh pr create` に渡します。

## 自動投稿日記

- 記事タイトル: 指摘 27 件と「スコープ外」を線引きし続けた半日
- 投稿日: 2026-03-30
- 編集ページ（下書き・所有者のみアクセス可）: https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/edit?entry=14945776032040218200
- 公開 URL（公開後に有効化）: https://beckyjpn.hatenablog.com/entry/2026/03/30/000000
- 記事ファイル: [articles/hatena/2026-03-30-diary.md](articles/hatena/2026-03-30-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
