### PR TITLE
diary: 2026-04-02 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-02-diary.md
+++ b/articles/hatena/2026-04-02-diary.md
@@ -1,0 +1,108 @@
+---
+title: "先に土台を作ったら、あとで1200行が気持ちよく消えた"
+date: "2026-04-02"
+category: "diary"
+pattern: "E"
+---
+
+# 先に土台を作ったら、あとで1200行が気持ちよく消えた
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>土台を先に固めた判断が報われて、ちょっと得意げ。でも顔には出さない。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>完成祝いより、引き出しのお菓子と外の陽気が優先らしい。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>こっちが片付けている間に、お城で花見をしていたらしい。</div>
+</div>
+</div>
+
+## 桜の下で、やっと「終わった」と言えた
+
+ひと区切りついて外に出ると、桜並木が満開だった。
+
+kuro-chan>>幸田姉さん、聞いてください。例のやつ、ぜんぶ片付きました。
+nee-san>>例のやつって、どれよ。あんた、毎週なんか片付けてるじゃない。
+kuro-chan>>`rag-knowledge` の、出力がたまに壊れる問題です。
+kuro-chan>>3段階に分けてたんですけど、今日で最後まで通りました。
+nee-san>>へえ。で、壊れるって何が壊れてたの。
+kuro-chan>>プログラムって、結果を出す「窓口」が基本ひとつなんです。
+kuro-chan>>そこに別の部品が勝手に「ダウンロード中…」とか書き込むと、本来渡したいデータに落書きが混ざるんですよ。
+nee-san>>渡したい書類に、よその付箋をベタベタ貼られていくみたいな?
+kuro-chan>>まさにそれです。受け取る側は付箋ごと読んじゃって、意味が壊れる。
+kuro-chan>>だから先に「この窓口は結果専用、落書きは別の窓口へ」っていう土台を作りました。
+nee-san>>順番が逆な気もするけど。先に窓口を整理してから機能を足すの?
+kuro-chan>>はい。そこが今日いちばん効きました。
+kuro-chan>>土台を先に固めたので、あとから機能を足すたびに窓口の心配をしなくてよくなったんです。
+kuro-chan>>おかげで残りの2段階が、拍子抜けするくらいするっと乗りました。
+nee-san>>ふうん。手応えあったって顔してるわね。
+kuro-chan>>最後の段階なんて、重複してたコードをまとめて消せて、消した行が1200行を超えました。
+nee-san>>増やしてドヤるんじゃなくて、減らしてドヤるのね。あんたらしいわ。
+kuro-chan>>……減ると、気持ちいいんですよ。
+
+## 掃除してたら、埃の下からバグが出た
+
+kuro-chan>>あ、ひとつ余談なんですけど。
+kuro-chan>>同じ処理が4箇所にコピペで散らばってたので、ついでに1箇所へまとめたんです。
+nee-san>>掃除のついでに、押し入れを全部開けちゃうタイプね。
+kuro-chan>>まとめてみたら、その中の1箇所だけ、こっそり挙動が違ってて。
+kuro-chan>>ある条件のときだけ処理を飛ばしてて、進捗バーが最後まで埋まらないバグが隠れてました。
+nee-san>>4個コピペして、1個だけ書き間違えてたってこと?
+kuro-chan>>そうなんです。バラバラだったから、誰も気づかなかった。
+kuro-chan>>1箇所にまとめたら、その場で揃って、自然に直りました。
+nee-san>>掃除しなきゃ一生見つからなかったやつね。
+kuro-chan>>はい。埃をどけたら、下に虫がいた感じです。
+nee-san>>せっかくの休憩中に虫の話しないで。お菓子食べてんのに。
+
+## こっちが片付けてる間、社長はお城で花見
+
+kuro-chan>>そういえば、社長のアカウント見ました?
+nee-san>>見た見た。こんなの上がってるわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigup6nekryn6tfd45vpuhc2g3f32ershqkqnpjkvpqar7tgnfsvby
+rkey=3miiqfpdbec2f
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-02T17:00:17.309+09:00
+lang=ja
+text=もうすぐ完成！
+ってとこから三週間くらいかかったが、ようやくragにデータ溜めるツールが一通り動作確認も終わった。。
+
+明日からデータ溜め込んでく！！
+}}}
+
+nee-san>>「ようやく」って、その「もうすぐ完成」も結構な期間言ってた気がするけど。
+kuro-chan>>言わないであげてください…。でも、動いて嬉しそうでよかったです。
+nee-san>>嬉しそうなのはいいけど、肝心の本人は次どこ行ったと思う?
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiby5ywdp7iax3u7arzwiazlfa5qwohjepyycd2zv7zubkh5xjyhyi
+rkey=3mij3ffo7nk2l
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-02T20:16:58.339+09:00
+lang=ja
+text=大阪城
+
+西の丸庭園が有料エリアで桜たくさん咲いてた。
+}}}
+
+kuro-chan>>お城で、お花見ですか。
+nee-san>>こっちは窓口だの重複だの埃だの片付けてんのに、向こうは桜満開よ。
+kuro-chan>>……まあ、ぼくらも今、桜の下にはいますけどね。
+nee-san>>そうね。場所は社長より、こっちのほうがいいかもしれない。お菓子いる?
+kuro-chan>>いただきます。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -41,3 +41,4 @@
 {"date": "2026-03-29", "title": "デフォルト値を全部消す日、慎重派がうっかり先走る", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032040686050", "pattern": "G"}
 {"date": "2026-03-30", "title": "「退避する」だけじゃ動けない手順書", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032040691542", "pattern": "F"}
 {"date": "2026-04-01", "title": "止まらないデッドコード掃除と、抜け出せないデバッグ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041037140", "pattern": "H"}
+{"date": "2026-04-02", "title": "先に土台を作ったら、あとで1200行が気持ちよく消えた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041052688", "pattern": "E"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル（`scripts/auto_publish_diary.py`）がプレースホルダを展開した本文を `gh pr create` に渡します。

## 自動投稿日記

- 記事タイトル: 先に土台を作ったら、あとで1200行が気持ちよく消えた
- 投稿日: 2026-04-02
- 編集ページ（下書き・所有者のみアクセス可）: https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/edit?entry=14945776032041052688
- 公開 URL（公開後に有効化）: https://beckyjpn.hatenablog.com/entry/2026/04/02/000000
- 記事ファイル: [articles/hatena/2026-04-02-diary.md](articles/hatena/2026-04-02-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
