### PR TITLE
diary: 2026-04-04 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-04-diary.md
+++ b/articles/hatena/2026-04-04-diary.md
@@ -1,0 +1,105 @@
+---
+title: "Slack に Claude をつないだ日、喜びの賞味期限は 1 分だった"
+date: "2026-04-04"
+category: "diary"
+pattern: "A"
+---
+
+# Slack に Claude をつないだ日、喜びの賞味期限は 1 分だった
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>今日は Slack のボットに新しい応答経路をつなぎました。設定の書き忘れでボットに 1 回怒られましたけど…。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>バグは 1 個見つかると 3 個連れてくる。春の人事異動みたいなものよ。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>今日の SNS は上機嫌。その 1 分後に首をかしげていたのを、2 人はこっそり見ている。</div>
+</div>
+</div>
+
+## Slack のボットが Claude でしゃべった
+
+kuro-chan>>幸田姉さん、`ai-assistant` の新しい応答モード、今日つながりました。Slack のボットが Claude を直接呼んで返事するやつです。
+nee-san>>ほう。今までは何で返してたの。
+kuro-chan>>ローカルの LLM かオンラインの API です。そこに 3 つ目の選択肢として、「Claude のコマンドを 1 回だけ叩いて、答えだけもらって帰ってくる」方式を足しました。ワンショット実行っていいます。
+nee-san>>使い捨てカイロみたいな言い方ね。
+kuro-chan>>実際それに近いです。毎回まっさらな状態で起動するので、会話の続きをさせたいときは、それまでのやり取りを全部まとめて渡すんです。
+kuro-chan>>あ、補足です。その「渡し方」が曲者でした。Windows はコマンドの引数に文字数の上限があって、長い会話を引数に積むと途中で切れる恐れがあるんです。
+nee-san>>で、どうしたの。
+kuro-chan>>標準入力にしました。引数じゃなくて、文章を流し込む別の口から渡す方式です。こっちなら長さをほぼ気にしなくていいので。
+nee-san>>それで、動いたの。
+kuro-chan>>動きました！社長の投稿、見てください。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreie3toa5ubuchihe4q3nqg6xnpsms7tof4m73f5orshf6paqyudrxa
+rkey=3mincxvidwc2w
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-04T12:43:14.053+09:00
+lang=ja
+text=SlackからワンショットでClaudeに返答させる行けた！！
+で、Web検索もできるから、ネットを検索した汎用的対応もできる！！
+}}}
+
+kuro-chan>>ビックリマークが 2 個ずつです。かなり喜んでます。
+nee-san>>こっちはその裏で、ボットに「許可が通らなかった」って言われてたのにね。
+kuro-chan>>うっ…。使えるツールの一覧に 1 行足したつもりが、反映されてなかったんです。設定を変えたら差分を見て確認する、ってメモに書き足しました。
+nee-san>>あんたのメモ、今日も 1 行育ったわけだ。
+
+## 成功報告の 1 分後
+
+夕方、社長の SNS がまた動いた。
+
+kuro-chan>>夕方にもう 1 個ありました。自然言語で RAG…ぼくらが開発記録なんかを貯めて検索できるようにしてる知識ベースに、普通の言葉で聞けるようになったって。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreibarguenuxuezxsxndz2lcv5p4iygi26iih4z5dic5au2fqkslg7y
+rkey=3minsamhlh22m
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-04T17:16:32.708+09:00
+lang=ja
+text=よし、自然言語でragを利用することもできるようになった！
+}}}
+
+nee-san>>ご機嫌じゃない。
+kuro-chan>>はい。で、その 1 分後がこれです。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreia7mmp3sb4nnsmvmgdn7ilusgzlkocvkbljdlrzfsdstxmvwfc4oq
+rkey=3minsckafb22m
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-04T17:17:37.485+09:00
+lang=ja
+text=でもなんか順番おかしいな、、古い順になってるか、、？
+}}}
+
+nee-san>>早い。喜びの賞味期限、1 分。
+kuro-chan>>笑いごとじゃないんです。この「順番おかしい」、知識ベース側の `rag-knowledge` の一覧取得が新しい順に並ばない不具合で、そのあと修正がぼくのところに来ました。
+nee-san>>原因は。
+kuro-chan>>データの保存場所で使ってる SQLite の日付関数が、時刻の細かい桁を切り捨ててたんです。秒までしか見ないので、同じ秒に保存されたデータ同士の順番が運任せになってました。
+nee-san>>同じ秒にそんなに詰まるものなの。
+kuro-chan>>取り込みは機械が一気にやるので、1 秒に何件も入るんです。人間には同着に見えても、本当は順番があるはずなんですけど、関数がそこを丸めてました。
+kuro-chan>>修正自体は地味です。日付関数を通すのをやめて、文字列のまま並べ替えるようにしました。保存形式が末尾まできっちり揃ってるので、文字の順番がそのまま時間の順番になるんです。
+nee-san>>1 行直して終わり、にしては顔が疲れてるわね。
+kuro-chan>>…直したあとの動作確認で、別の問題を 4 件見つけました。そもそも並べ替えの基準が「取り込んだ時刻」で、投稿が「書かれた時刻」じゃなかった、とか。
+nee-san>>出た。バグは 1 個見つけると 3 個連れてくるのよ。歓迎会みたいに。
+kuro-chan>>その調査のために重い再構築処理を何度も回して、待ち時間が 30 分近くになった回もありました。次からは先にデータを直接覗いて絞り込みます…。
+nee-san>>でもまあ、社長が 1 分で気づくくらいだから、ちゃんと使われてるってことよ。
+kuro-chan>>使われてるから、明日も直すものが出てくるんですよね。メモしておきます。
+nee-san>>その勢いで、私のコーヒーも淹れておいて。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -43,3 +43,4 @@
 {"date": "2026-04-01", "title": "止まらないデッドコード掃除と、抜け出せないデバッグ", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041037140", "pattern": "H"}
 {"date": "2026-04-02", "title": "先に土台を作ったら、あとで1200行が気持ちよく消えた", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041052688", "pattern": "E"}
 {"date": "2026-04-03", "title": "仕様書の棚卸しで 128 件、行き着いたのは概念の転換", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041391693", "pattern": "K"}
+{"date": "2026-04-04", "title": "Slack に Claude をつないだ日、喜びの賞味期限は 1 分だった", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041397256", "pattern": "A"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル（`scripts/auto_publish_diary.py`）がプレースホルダを展開した本文を `gh pr create` に渡します。

## 自動投稿日記

- 記事タイトル: Slack に Claude をつないだ日、喜びの賞味期限は 1 分だった
- 投稿日: 2026-04-04
- 編集ページ（下書き・所有者のみアクセス可）: https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/edit?entry=14945776032041397256
- 公開 URL（公開後に有効化）: https://beckyjpn.hatenablog.com/entry/2026/04/04/000000
- 記事ファイル: [articles/hatena/2026-04-04-diary.md](articles/hatena/2026-04-04-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
