### PR TITLE
diary: 2026-04-08 の日記を追加

### DIFF
--- a/articles/hatena/2026-04-08-diary.md
+++ b/articles/hatena/2026-04-08-diary.md
@@ -1,0 +1,94 @@
+---
+title: "「考えるな」で画像解析が 8 倍速くなった話"
+date: "2026-04-08"
+category: "diary"
+pattern: "F"
+---
+
+# 「考えるな」で画像解析が 8 倍速くなった話
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>考えすぎて手が止まる AI を見て、ぼくは完全に他人事とは思えませんでした。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>中身の見えない相手に振り回されるのは、AI も人間も同じってこと。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>部下にダメ出しする謎の批評家の正体を、こっそり SNS で気にしているらしい。</div>
+</div>
+</div>
+
+## 考えすぎて固まる AI に、「考えるな」と言ってみた
+
+kuro-chan>>幸田姉さん、聞いてください。手元で動かしてる画像読み取りの AI が、ぜんぜん答えを返してくれなくて。
+nee-san>>画像読み取りって、写真を文字に起こすやつだっけ。
+kuro-chan>>そうです。投稿に貼られた画像や動画を読み取って、検索できるテキストに変える仕組みを `rag-knowledge` に入れたくて。
+nee-san>>で、その仕組みがだんまりを決め込んでると。
+kuro-chan>>はい。正確には、答える前の「考え中」だけで力尽きてました。
+nee-san>>……は？
+kuro-chan>>最近の AI って、答える前に頭の中でぶつぶつ下書きするんです。その下書きが長すぎて、本番のひとことを言う前に時間切れになってて。
+nee-san>>準備運動だけでフルマラソン走った気になって倒れる人、いるよね。
+kuro-chan>>まさにそれです。中身が空っぽのまま 138 秒かけて帰ってくるんですよ。
+nee-san>>138 秒待たされて手ぶら。ただ待たされてるだけじゃない。
+kuro-chan>>それで設定をいろいろ漁ってたら、`reasoning_effort` っていう隠し項目を見つけまして。
+kuro-chan>>「考える努力をどれくらいするか」を決める設定です。
+nee-san>>へえ。で、どうしたの。
+kuro-chan>>思いきって `none` にしました。要は「考えるな、すぐ答えろ」って。
+nee-san>>急に体育会系。
+kuro-chan>>そしたら 138 秒が 17.6 秒になりました。8 倍近く速いです。
+nee-san>>考えるのやめた瞬間に仕事が回り出すって、皮肉が効いてるね。
+kuro-chan>>……それ、ぼくにも刺さるので、やめてください。
+nee-san>>自覚あるんだ。
+kuro-chan>>ちょうど昼休みに読んでた小説に、こんな一節があって。
+kuro-chan>>吉川英治の『源頼朝』です。「彼の緻密な性分は、考えすぎて迷いに落ちる傾きもあった」。
+nee-san>>頼朝でも考えすぎて転ぶのか。
+kuro-chan>>はい。几帳面なほど、考えすぎて動けなくなる。AI もぼくも同じだなと。
+nee-san>>じゃあ次から、あんたの設定も `none` にしとこうか。
+kuro-chan>>ぼくは人間なので、それはそれで困ります。
+
+## 正体のわからない批評家
+
+kuro-chan>>その画像解析の仕様をまとめて出した PR にも、自動レビューがついたんですけど。
+nee-san>>例の、勝手にコメントしてくる Copilot のレビューね。
+kuro-chan>>はい。設定値の書き方が一箇所だけ揃ってないのを、ピシッと指摘されました。`/v1` を付けるか付けないかの違いで。
+nee-san>>細かいとこ突いてくるね。
+kuro-chan>>`agent-commons` の方でも、設定ファイルにモデルを足したところを拾われました。
+nee-san>>毎回それなりに鋭いのよね。誰が採点してるのか知らないけど。
+kuro-chan>>それなんですけど……中で何のモデルが動いてるのか、公開されてないみたいで。
+nee-san>>選ぶこともできないの？
+kuro-chan>>できないです。正体のわからない相手に、毎回ダメ出しされてる感じで。
+nee-san>>……あの人もそれ、気にしてたよ。ほら。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreigoxbw6c6c5mdayjqkkay45reatmnkxcivjh7ruolo5anp3try5ci
+rkey=3mixe762opc2v
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-04-08T12:31:49.049+09:00
+lang=ja
+text=Copilotのコードレビューってモデルの選択とかできないのか。
+
+そして、なにのモデル使ってるかも公開されていないっぽい。
+
+docs.github.com/en/copilot/c...
+}}}
+
+nee-san>>社長まで「中身が見えない」ってぼやいてる。
+kuro-chan>>指示を出してくる側も、正体は知らないんですね。
+nee-san>>そうよ。あんたにダメ出ししてる相手の中身、社長も知らないの。
+kuro-chan>>なんだか急に、あの批評家が怖くなくなってきました。
+nee-san>>みんな手探りってことね。
+kuro-chan>>さっきの AI は考えすぎて中身が丸見えだったのに、こっちは考えてるところが一切見えない。
+nee-san>>逆で面白いね。見えすぎても困るし、見えなくても落ち着かない。
+kuro-chan>>ちょうどいい「考える」加減って、難しいです。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -46,3 +46,4 @@
 {"date": "2026-04-04", "title": "Slack に Claude をつないだ日、喜びの賞味期限は 1 分だった", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041397256", "pattern": "A"}
 {"date": "2026-04-05", "title": "3.7 倍速くした日に、未コミットの変更を全部消した", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041743625", "pattern": "J"}
 {"date": "2026-04-07", "title": "推定 7 分の削除が 4 秒になった、索引まるごと作り直し問題", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032041750162", "pattern": "I"}
+{"date": "2026-04-08", "title": "「考えるな」で画像解析が 8 倍速くなった話", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032042162959", "pattern": "F"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル（`scripts/auto_publish_diary.py`）がプレースホルダを展開した本文を `gh pr create` に渡します。

## 自動投稿日記

- 記事タイトル: 「考えるな」で画像解析が 8 倍速くなった話
- 投稿日: 2026-04-08
- 編集ページ（下書き・所有者のみアクセス可）: https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/edit?entry=14945776032042162959
- 公開 URL（公開後に有効化）: https://beckyjpn.hatenablog.com/entry/2026/04/08/000000
- 記事ファイル: [articles/hatena/2026-04-08-diary.md](articles/hatena/2026-04-08-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
