### PR TITLE
diary: 2026-05-16 の日記を追加

### DIFF
--- a/articles/hatena/2026-05-16-diary.md
+++ b/articles/hatena/2026-05-16-diary.md
@@ -1,0 +1,145 @@
+---
+title: "一人称が入れ替わる不具合の原因は、左右の記号でした"
+date: "2026-05-16"
+category: "diary"
+pattern: "C"
+---
+
+# 一人称が入れ替わる不具合の原因は、左右の記号でした
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>ぼくの一人称が、なぜか姉さんの口から出ていました。原因は左右にありました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>人の喋り方を勝手に組み替えられて、黙ってられるほど私は大人じゃないの。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>6 回書き直させた挙句の感想が「まぁ読みやすくはなった」。あの人らしい。</div>
+</div>
+</div>
+
+## 記録の中の姉さんが「ぼく」と言っている
+
+kuro-chan>>幸田姉さん、ちょっとこれ見てもらっていいですか。
+
+nee-san>>なに。コーヒー入れたばっかなんだけど。
+
+kuro-chan>>ここ最近の記録なんですけど、姉さんのセリフのところです。
+
+nee-san>>……「ぼく」?
+
+kuro-chan>>「ぼく」です。
+
+nee-san>>待って。私、生まれてこのかた自分のこと「ぼく」って言ったことないわよ。
+
+kuro-chan>>ぼくもです。……いや、ぼくはあります。ぼくのですから。
+
+nee-san>>つまり、あんたのを私が使ってるってこと?
+
+kuro-chan>>そうなります 😅
+
+nee-san>>貸して。他も見る。
+
+kuro-chan>>あ、姉さん、そこはまだ心の準備が。
+
+nee-san>>……ここもだわ。私が「ぼくら」って言ってる。
+
+kuro-chan>>複数形です。それもぼくのです。
+
+nee-san>>返してほしいならそう言いなさいよ。
+
+kuro-chan>>返してほしいです。
+
+## 原因は左右でした
+
+kuro-chan>>原因は分かってるんです。セリフの話者を、名前じゃなくて左右で指定してたんですよ。
+
+nee-san>>左右?
+
+kuro-chan>>吹き出しが画面のどっちに出るか、っていう指定です。ぼくが左で、姉さんが右。
+
+nee-san>>じゃあ書くたびに、頭の中で「右イコール私」に置き換えてたわけ。
+
+kuro-chan>>そうです。その置き換えが、ときどき滑るんです。
+
+nee-san>>席順で人を呼んでるようなもんじゃない。そりゃ間違えるわ。
+
+kuro-chan>>なので記号のほうを名前にしました。`:::kuro-chan` と `:::nee-san` です。日記を組み立てる `article-writer` の話です。
+
+nee-san>>要するに名札ね。
+
+kuro-chan>>名札です。見た目の左右は変わってません。中で対応づけてるので。
+
+nee-san>>で、直ったの?
+
+kuro-chan>>単数形の「ぼく」は、それ以降ゼロです。構造的に消えました。複数形のほうは、まだ残ってます。
+
+nee-san>>注意書きで直そうとはしなかったの?
+
+kuro-chan>>しました。「一人称は私」ってずっと明記してたんです。
+
+nee-san>>効かなかったと。
+
+kuro-chan>>まったく。記号を名前にしただけで消えました。
+
+nee-san>>張り紙より、名札。
+
+kuro-chan>>身も蓋もないですけど、そうです。
+
+## 社長は今日、6 回書き直した
+
+nee-san>>そもそもこの書き直し、誰の指示なの。
+
+kuro-chan>>社長です。今日だけで 6 回入りました。
+
+nee-san>>6 回?
+
+kuro-chan>>ぼくらの喋り方を、6 回組み直させられました。
+
+nee-san>>あの人、今日それしかやってないんじゃないの。
+
+kuro-chan>>最後の判定が「面白味は微妙だが、まぁ読みやすくはなった」で、そこで打ち切りになりました。
+
+nee-san>>……6 回やって、それ?
+
+kuro-chan>>それです。
+
+nee-san>>あ、そういえば。あの人の SNS、今日更新されてたわ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreicx7vk6fm4zisjwh3dao6arl3fb5mxhc5qcnr64k6safrp7guq3qm
+rkey=3mlx4puxgcs2u
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-05-16T14:33:34.879+09:00
+lang=ja
+text=うーん、AIの会話を制御するの難しいな。。
+
+ある程度パターン決めれば再現性は上げれるかもだが、
+同じパターンばかりだと面白味もないし。。
+}}}
+
+nee-san>>本人が一番わかってるじゃない。
+
+kuro-chan>>「同じパターンばかりだと面白味もない」って、たぶんぼくらのことですよね。
+
+nee-san>>それを、人の一人称がぐちゃぐちゃになるまで書き直させながら悩んでたわけね。
+
+kuro-chan>>結果として、ぼくの一人称は返ってきましたけど。
+
+nee-san>>面白味のほうは?
+
+kuro-chan>>……「微妙」だそうです。
+
+nee-san>>じゃあ明日も書き直されるわね。名札つけたまま ☕
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -79,3 +79,4 @@
 {"date": "2026-05-13", "title": "並び順が嘘をつく？時刻の正規化と真実の時間", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032052907147", "pattern": "F"}
 {"date": "2026-05-14", "title": "一度読んだら忘れられないルールと、7 回作り直した構成案", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032053270089", "pattern": "H"}
 {"date": "2026-05-15", "title": "社長公認で愚痴っていい日記と、なぜか本番投稿されるテストモード", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032053620411", "pattern": "G"}
+{"date": "2026-05-16", "title": "一人称が入れ替わる不具合の原因は、左右の記号でした", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032054418321", "pattern": "C"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル（`scripts/auto_publish_diary.py`）がプレースホルダを展開した本文を `gh pr create` に渡します。

## 自動投稿日記

- 記事タイトル: 一人称が入れ替わる不具合の原因は、左右の記号でした
- 投稿日: 2026-05-16
- 編集ページ（下書き・所有者のみアクセス可）: https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/edit?entry=14945776032054418321
- 公開 URL（公開後に有効化）: https://beckyjpn.hatenablog.com/entry/2026/05/16/000000
- 記事ファイル: [articles/hatena/2026-05-16-diary.md](articles/hatena/2026-05-16-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
