### PR TITLE
fix(auto-publish-diary): finalize 未実行ガードと worktree 残骸掃除を追加

### DIFF
--- a/.claude/scripts/auto-publish-stop-guard.sh
+++ b/.claude/scripts/auto-publish-stop-guard.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# /auto-publish-diary の finalize 未実行ガード（Stop hook）
+#
+# setup が作成する in-flight マーカーが残ったまま（= result.json 未書き込み = finalize 未到達）
+# セッションが停止しようとしたとき、停止をブロックして finalize の実行を指示する。
+# 記事生成（LLM ステップ）後に end_turn で打ち切られると決定論的な後続処理（投稿・PR・
+# result.json）が丸ごと飛ぶ構造弱点への L2 ガード。
+#
+# 誤爆防止:
+# - セッション自己識別: setup が記録したセッション ID（session-id ファイル）と一致する
+#   セッションのみブロック対象。並行する開発セッションは構造的に対象外（二重 finalize 防止）
+# - マーカー作成から 2 時間超は非ブロック（クラッシュ残骸が通常セッションを妨げないため）
+# - ブロックは 1 実行あたり最大 2 回（カウンタは setup でリセット、result.json 書き込みで削除）
+#
+# マーカー・カウンタ・session-id のライフサイクルは scripts/write_auto_publish_result.py を参照。
+set -u
+
+# stdin(JSON) はセッション照合のフォールバック用に保持する（判定の主軸はファイル状態）
+STDIN_JSON=$(cat 2>/dev/null || true)
+
+# 親リポジトリを git から導出する（cwd が worktree 内でも親リポの .git を指す）。git 外なら何もしない
+COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
+if [ -z "$COMMON_DIR" ]; then
+  exit 0
+fi
+PARENT_REPO=$(dirname "$COMMON_DIR")
+STATE_DIR="$PARENT_REPO/.tmp/auto-publish-diary"
+MARKER="$STATE_DIR/in-flight"
+RESULT="$STATE_DIR/result.json"
+COUNTER="$STATE_DIR/stop-block-count"
+SESSION_FILE="$STATE_DIR/session-id"
+
+# in-flight マーカーが無い（自動投稿の実行中でない）/ result.json 済み（終端到達済み）なら通常停止
+if [ ! -f "$MARKER" ]; then
+  exit 0
+fi
+if [ -f "$RESULT" ]; then
+  exit 0
+fi
+
+# セッション自己識別: setup が記録したセッション ID と一致するセッションのみブロック対象。
+# 記録が無い・照合材料が無い場合は fail-open（ブロックしない）
+if [ ! -f "$SESSION_FILE" ]; then
+  exit 0
+fi
+RECORDED_SID=$(tr -d '[:space:]' < "$SESSION_FILE")
+if [ -z "$RECORDED_SID" ]; then
+  exit 0
+fi
+HOOK_SID="${CLAUDE_CODE_SESSION_ID:-}"
+if [ "$HOOK_SID" != "$RECORDED_SID" ]; then
+  # env に無い環境向けフォールバック: hook stdin JSON の session_id と照合する
+  STDIN_SID=$(printf '%s' "$STDIN_JSON" \
+    | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+  if [ "$STDIN_SID" != "$RECORDED_SID" ]; then
+    exit 0
+  fi
+fi
+
+# マーカーが古すぎる場合はブロックしない
+NOW=$(date +%s)
+MARKER_MTIME=$(stat -c %Y "$MARKER" 2>/dev/null) || {
+  # fail-open（ガード無効化）で通常停止に倒すが、黙って無効化すると診断できないため痕跡を残す
+  echo "auto-publish-stop-guard: stat failed for $MARKER (guard skipped)" >&2
+  exit 0
+}
+MAX_AGE_SECONDS=7200
+if [ $((NOW - MARKER_MTIME)) -gt "$MAX_AGE_SECONDS" ]; then
+  exit 0
+fi
+
+# ブロック回数の上限（無限ループ防止）
+COUNT=""
+if [ -f "$COUNTER" ]; then
+  COUNT=$(tr -cd '0-9' < "$COUNTER")
+fi
+COUNT=${COUNT:-0}
+MAX_BLOCKS=2
+if [ "$COUNT" -ge "$MAX_BLOCKS" ]; then
+  exit 0
+fi
+echo $((COUNT + 1)) > "$COUNTER" 2>/dev/null || true
+
+cat <<'JSON'
+{"decision": "block", "reason": "/auto-publish-diary の finalize が未実行です（in-flight マーカーあり・result.json 不在）。.claude/skills/auto-publish-diary/SKILL.md のステップ 2〜3 に従い、worktree 内の生成記事の相対パスを特定し、親リポジトリを cwd にして `python \"$WORKTREE/scripts/auto_publish_diary.py\" finalize --worktree \"$WORKTREE\" --article-path <記事相対パス>` を実行してください。記事が未生成でも finalize を実行すれば failed_phase=write の result.json が書かれて正常に終端します。result.json の書き込みを確認してから終了してください。"}
+JSON
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "env": {
     "WORKTREE_DISABLED": "1"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/auto-publish-stop-guard.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/auto-publish-diary/SKILL.md
+++ b/.claude/skills/auto-publish-diary/SKILL.md
@@ -68,6 +68,16 @@ result.json のスキーマ・各キーの意味・正規化ルール・`status`
 | 0 | 全 Phase 成功（worktree 削除の成否によらず）。result.json は `status=ok` |
 | 1 | 失敗（result.json に `status=error` を書き込み済み。worktree は残置） |
 
+### 実行状態ファイル（in-flight マーカー）
+
+result.json と同じディレクトリ（`$PARENT_REPO/.tmp/auto-publish-diary/`）に、finalize 未到達検出用の状態ファイルを置く。ファイル名・ライフサイクルの SSoT は `scripts/write_auto_publish_result.py` のモジュール定数と docstring。
+
+| ファイル | 作成 | 削除 | 意味 |
+|---|---|---|---|
+| `in-flight` | `setup` 成功時 | result.json 書き込み時（成功・失敗とも） | 残存 + result.json 不在 = setup 成功後〜result.json 書き込み前に実行が途切れた（記事生成の途中で途絶したケースを含む） |
+| `stop-block-count` | Stop hook がブロック時に加算 | `setup` でリセット、result.json 書き込み時に削除 | Stop hook の無限ブロック防止カウンタ |
+| `session-id` | `setup` 成功時（自セッションの `CLAUDE_CODE_SESSION_ID` を記録） | result.json 書き込み時 | Stop hook がブロック対象を自動投稿セッション自身に限定するための自己識別子（並行セッションの誤ブロック防止） |
+
 ## 処理手順
 
 `scripts/auto_publish_diary.py` の `setup` / `finalize` を起動し、その間に LLM ステップ（記事生成）を挟む。各 Python コマンドが result.json への書き込みと終了コードを自前で行うため、本スキルは終了コードを見て分岐するだけでよい。
@@ -77,6 +87,7 @@ result.json のスキーマ・各キーの意味・正規化ルール・`status`
 親リポジトリの直下で **1 回だけ** 実行し、出力をファイルに保存してから終了コードを判定する（`setup` を 2 回起動するとブランチ名重複で必ず失敗するため、二重起動は厳禁）:
 
 ```bash
+PARENT_REPO=$(pwd)
 mkdir -p .tmp/auto-publish-diary
 SETUP_LOG=.tmp/auto-publish-diary/setup-stdout.log
 python scripts/auto_publish_diary.py setup > "$SETUP_LOG"
@@ -88,9 +99,12 @@ fi
 WORKTREE=$(grep '^WORKTREE: ' "$SETUP_LOG" | sed 's/^WORKTREE: //')
 ```
 
+`PARENT_REPO` はステップ 3 で親リポへ cd 復帰するために保持する。
+
 `setup` の責務:
 
-- 親リポ検証・clean 確認・main 最新化・worktree 作成・`.env` コピーを行う
+- 親リポ検証・clean 確認・main 最新化・前回残骸の掃除（`git worktree prune` + 空の `<repo>-wt-auto-*` ディレクトリ削除。非空の残骸は未リカバリ記事を守るため削除せず警告のみ）・worktree 作成・`.env` コピーを行う
+- 成功時は in-flight マーカー（`.tmp/auto-publish-diary/in-flight`）を作成する。マーカーは result.json 書き込みで削除され、「マーカーあり + result.json 不在」が finalize 未到達のシグナルになる（Stop hook が参照。「注意事項」参照）
 - 成功時は stdout に `WORKTREE: <絶対パス>` と `BRANCH: <ブランチ名>` を出力する
 - 失敗時は result.json（`status=error`、`failed_phase=environment`）を書き込み終了コード 1 で終了する
 
@@ -128,12 +142,17 @@ ARTICLE_PATH=$(git -C "$WORKTREE" status --porcelain articles/hatena/ \
 
 ### ステップ 3: finalize（Phase 2〜5）
 
-worktree 内で実行する:
+**親リポへ cd 復帰してから**、**worktree 側の** スクリプトを実行する:
 
 ```bash
-cd "$WORKTREE"
-python scripts/auto_publish_diary.py finalize --article-path "$ARTICLE_PATH"
+cd "$PARENT_REPO"
+python "$WORKTREE/scripts/auto_publish_diary.py" finalize --worktree "$WORKTREE" --article-path "$ARTICLE_PATH"
 ```
+
+- 親リポへ戻る理由: セッションの作業 cwd が worktree を掴んだまま Phase 4 の削除に入ると、Windows のディレクトリロック（`git worktree remove` の rmdir 段階の Permission denied、#245）の一因になりうるため、削除前に cwd を worktree の外へ出す
+- worktree 側のスクリプトを起動する理由: `publish_hatena` が `__file__` 基準で `.env` / `published.jsonl` を解決するため。親リポ側スクリプトを起動した場合は finalize 冒頭のガードが `failed_phase=environment` で検出する
+
+`finalize` の処理内容:
 
 - Phase 2: `publish_hatena.py` を subprocess 起動して下書き登録 → `published.jsonl` から `edit_url` を読み、編集ページ URL・公開 URL を組み立てる
 - Phase 3: git add / commit / push / `gh pr create` / `gh pr merge --squash --admin`（merge が exit 非 0 のときは `gh pr view --json state` で `MERGED` を確認できれば継続。Why は「注意事項」参照）
@@ -141,7 +160,7 @@ python scripts/auto_publish_diary.py finalize --article-path "$ARTICLE_PATH"
 - Phase 5: `status=ok` の result.json を書き込む
 - いずれかの Phase で失敗したら、`failed_phase` 付きの result.json を書き込み終了コード 1 で終了する
 
-`finalize` は `git rev-parse` で parent_repo / worktree / branch を導出するため、本スキルから渡すのは `--article-path` のみ。
+`finalize` は `--worktree` を基準に `git rev-parse` で parent_repo / branch を導出する（`--worktree` 省略時は従来互換で cwd から導出）。本スキルから渡すのは `--worktree` と `--article-path` のみ。
 
 ## エラーハンドリング一覧
 
@@ -150,6 +169,7 @@ result.json への書き込みと終了コードは `scripts/auto_publish_diary.
 | 状況 | failed_phase | 後続 |
 |---|---|---|
 | worktree 内からの起動 / 親リポに未コミット変更 / `git switch main`・`pull` 失敗 / 同名ブランチ既存 / `git worktree add` 失敗 / `.env` 不整合 | environment | 以降スキップ |
+| finalize の起動ミス（`--worktree` のパス不在 / 親リポ側スクリプトでの finalize 起動をガードが検出） | environment | publish 以降スキップ、worktree 残置（正しい起動形で finalize を再実行できる） |
 | `/write-hatena-diary` 失敗・生成記事 0 件（`finalize` に空パスが渡る。記事ファイル自体が生成されていない場合に限る。Phase 10 出力欠落でファイルは生成されている場合はステップ 2 のフォールバックで救済される） | write | publish 以降スキップ、worktree 残置 |
 | `publish_hatena.py` 失敗（HTTP 4xx/5xx・keyring 未登録等）/ 編集 URL 組み立て失敗 | publish | git 以降スキップ、worktree + 記事 md は残置（再投稿可能） |
 | フロントマター読取失敗 / `git commit`・`push` 失敗 / `gh pr create` 失敗 / `gh pr merge` 失敗かつリモート state ≠ `MERGED` | git | 後続スキップ、worktree 残置 |
@@ -163,8 +183,10 @@ result.json への書き込みと終了コードは `scripts/auto_publish_diary.
 
 | failed_phase | 状態 | 推奨リカバリ |
 |---|---|---|
+| （result.json 不在・`in-flight` マーカー残存） | finalize 未到達。worktree 残置、Hatena 未投稿・PR なし（生成記事は残っている場合とない場合がある） | worktree 内の生成記事の相対パスを特定し、親リポを cwd に `python "<worktree>/scripts/auto_publish_diary.py" finalize --worktree "<worktree>" --article-path <相対パス>` を手動実行（記事が無い場合も finalize が `failed_phase=write` で終端させる。通常は Stop hook が停止をブロックしてセッション内で完遂させる） |
 | `environment`（worktree 未作成） | 何も変更されていない | 失敗理由を解消（親リポを clean に / 同名ブランチを削除等）してから再実行 |
 | `environment`（`.env` 不整合） | worktree のみ残置 | 親リポの `.env` を整備 → `git worktree remove --force <worktree_path>` で撤去 → 再実行 |
+| `environment`（finalize 起動ミス） | worktree + 生成記事が残置、Hatena 未投稿 | 正しい起動形（worktree 側スクリプト + `--worktree` 指定）で finalize を再実行 |
 | `write` | worktree 残置 | ジャーナル素材を補ってから再実行。原因不明なら worktree 内で `/write-hatena-diary --auto-publish` を手動デバッグ |
 | `publish` | 記事 md 生成済み、Hatena 未投稿 | worktree 内で `python scripts/publish_hatena.py <date>` を手動再実行（HTTP エラー等は時間を置く） |
 | `git` | 記事 md + Hatena 下書き登録済み | worktree 内で `git add articles/hatena/ && git commit -m "diary: <date> の日記を追加"` → push → PR → merge を手動実施 |
@@ -186,6 +208,11 @@ result.json への書き込みと終了コードは `scripts/auto_publish_diary.
 ## 注意事項
 
 - 本スキルは **無人実行** が前提。`claude -p` 非対話モードでは `AskUserQuestion` がエラー扱いされるため発行しない
+- **finalize 未実行ガード（Stop hook）**: `.claude/scripts/auto-publish-stop-guard.sh`（`.claude/settings.json` の `Stop` hook）
+  - 動作: 「`in-flight` マーカーあり + result.json 不在」の停止をブロックし、finalize の実行を指示する
+  - ブロック対象の限定: `session-id` に記録されたセッション（= setup を実行した自動投稿セッション）のみ。並行する開発セッションは照合不一致で即通常停止（fail-open）
+  - 誤爆防止: マーカー作成から 2 時間超は非ブロック。ブロックは 1 実行あたり最大 2 回（超過時は通常停止し、result.json 不在として ai-assistant 側の失敗検知に委ねる）
+  - 設計意図: 記事生成（長い LLM ステップ）後の end_turn 打ち切りで finalize が丸ごと飛ぶ構造弱点への多層防御
 - レビューでの修正適用は `/write-hatena-diary --auto-publish` 内の書き手自己判断に従う
 - PR は `gh pr merge --admin --squash` で即マージするため、ブランチ保護ルールがあっても通る。CI 実行は main へのマージ後（post-merge）に発生する想定
 - **Phase 3 merge の判定二段化**: `gh pr merge` の exit code が非 0 でも、続けて
@@ -202,6 +229,7 @@ result.json への書き込みと終了コードは `scripts/auto_publish_diary.
 ## 関連
 
 - `scripts/auto_publish_diary.py`: Phase 0・2〜5 のオーケストレーション本体（`setup` / `finalize`）
+- `.claude/scripts/auto-publish-stop-guard.sh`: finalize 未実行ガード（Stop hook 本体。`.claude/settings.json` で登録）
 - `.claude/skills/write-hatena-diary/SKILL.md`: 記事生成スキル本体（`--auto-publish` 経由で呼ぶ）
 - `.claude/skills/review-hatena-diary/SKILL.md`: レビュースキル（`--auto-publish` 経由で呼ばれ書き手自己判断）
 - `.claude/skills/publish-hatena/SKILL.md`: はてな AtomPub 投稿スキル

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# シェルスクリプトは常に LF でチェックアウトする（CRLF だと bash 実行時にエラーになるため。
+# core.autocrlf=true 環境でも hook スクリプト等が壊れないよう固定する）
+*.sh text eol=lf

--- a/scripts/auto_publish_diary.py
+++ b/scripts/auto_publish_diary.py
@@ -5,10 +5,16 @@
 記事生成（Phase 1）は `/write-hatena-diary` という Claude スキル（LLM）であり
 スクリプト化できないため、本スクリプトは LLM ステップを挟んで 2 エントリに分かれる:
 
-- `setup`: Phase 0（親リポ検証・clean 確認・main 最新化・worktree 作成・.env コピー）。
-  worktree パスを stdout に `WORKTREE: <path>` 形式で出力する。
-- `finalize --article-path <相対パス>`: Phase 2〜5（Hatena 投稿・git commit/push/PR/merge・
-  worktree クリーンアップ・result.json 書き込み）。worktree 内を cwd として起動する。
+- `setup`: Phase 0（親リポ検証・clean 確認・main 最新化・前回残骸の掃除・worktree 作成・
+  .env コピー・in-flight マーカー作成）。worktree パスを stdout に `WORKTREE: <path>` 形式で
+  出力する。
+- `finalize --article-path <相対パス> [--worktree <絶対パス>]`: Phase 2〜5（Hatena 投稿・
+  git commit/push/PR/merge・worktree クリーンアップ・result.json 書き込み）。
+  `--worktree` 指定時は親リポを cwd として起動できる（セッションの作業 cwd を worktree から
+  外して Windows の削除ロック要因を減らすため）。省略時は従来通り worktree 内 cwd から導出する。
+  いずれの場合も **worktree 側の** scripts/auto_publish_diary.py を起動すること
+  （publish_hatena が `__file__` 基準で .env / published.jsonl を解決するため。起動元の
+  取り違えは Phase 2 前のガードで failed_phase=environment として検出される）。
 
 共有核 `publish_hatena.py` への呼び出し方針（interface 混在方式）:
 
@@ -29,6 +35,7 @@ import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime
+from typing import NoReturn
 
 import publish_hatena
 import write_auto_publish_result
@@ -83,7 +90,7 @@ def _run(
     )
 
 
-def fail(state: PublishState, *, failed_phase: str, error: str) -> None:
+def fail(state: PublishState, *, failed_phase: str, error: str) -> NoReturn:
     """status=error の result.json を書き出して終了コード 1 で終了する（単一の失敗経路）。"""
     sys.stderr.write(f"[PHASE {failed_phase}] 失敗: {error}\n")
     result = write_auto_publish_result.build_result(
@@ -158,9 +165,7 @@ def cmd_setup() -> int:
     state = PublishState(parent_repo=parent_repo)
 
     # 前回残骸の result.json を削除する
-    result_path = (
-        pathlib.Path(parent_repo) / ".tmp" / "auto-publish-diary" / "result.json"
-    )
+    result_path = write_auto_publish_result.result_dir(parent_repo) / "result.json"
     result_path.parent.mkdir(parents=True, exist_ok=True)
     result_path.unlink(missing_ok=True)
 
@@ -196,6 +201,9 @@ def cmd_setup() -> int:
     worktree_path = os.path.join(parent_dir, f"{repo_name}-wt-auto-{now.strftime('%Y%m%d')}")
     state.branch_name = branch_name
 
+    # 前回実行の残骸を掃除する（今回の worktree 作成前）
+    sweep_stale_auto_worktrees(parent_repo, repo_name, parent_dir)
+
     # 同名ブランチ既存（同日二重実行）の事前検査
     if _run(
         ["git", "-C", parent_repo, "rev-parse", "--verify", f"refs/heads/{branch_name}"]
@@ -225,31 +233,185 @@ def cmd_setup() -> int:
             error=".env に HATENA_ID または HATENA_BLOG_ID が未設定",
         )
 
+    create_in_flight_marker(parent_repo, now.isoformat())
+
     print("[PHASE environment] 完了")
     print(f"WORKTREE: {worktree_path}")
     print(f"BRANCH: {branch_name}")
     return 0
 
 
+def create_in_flight_marker(parent_repo: str, timestamp: str) -> None:
+    """in-flight マーカーを作成し、Stop hook 用のセッション状態を初期化する。
+
+    マーカーは Stop hook が finalize 未実行の検出に使い、result.json 書き込み
+    （成功・失敗とも）で write_result_file が削除する。あわせて:
+
+    - 前回の Stop hook カウンタをリセット（削除）する
+    - 自セッションの `CLAUDE_CODE_SESSION_ID` を session-id ファイルに記録する。
+      Stop hook は記録された ID と一致するセッションのみブロックする（並行する
+      開発セッションの誤ブロック・二重 finalize を防ぐ）。env が無い環境
+      （claude 外からの手動実行等）では記録せず、ガードは発火しない（fail-open）
+
+    いずれの操作も失敗時はガードが効かなくなるだけなので、警告を出して実行自体は続行する。
+    """
+    marker_dir = write_auto_publish_result.result_dir(parent_repo)
+    try:
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        (marker_dir / write_auto_publish_result.IN_FLIGHT_FILENAME).write_text(
+            timestamp + "\n", encoding="utf-8"
+        )
+    except OSError as exc:
+        sys.stderr.write(f"WARNING: in-flight マーカーの作成に失敗（続行）: {exc}\n")
+    try:
+        (marker_dir / write_auto_publish_result.STOP_BLOCK_COUNT_FILENAME).unlink(
+            missing_ok=True
+        )
+    except OSError as exc:
+        sys.stderr.write(f"WARNING: Stop hook カウンタのリセットに失敗（続行）: {exc}\n")
+    session_file = marker_dir / write_auto_publish_result.SESSION_ID_FILENAME
+    session_id = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
+    try:
+        # 前回残骸の古い ID を確実に消してから、今回のセッション ID を記録する
+        session_file.unlink(missing_ok=True)
+        if session_id:
+            session_file.write_text(session_id + "\n", encoding="utf-8")
+        else:
+            sys.stderr.write(
+                "WARNING: CLAUDE_CODE_SESSION_ID が未設定のため Stop hook ガードは発火しません\n"
+            )
+    except OSError as exc:
+        sys.stderr.write(f"WARNING: session-id の記録に失敗（続行）: {exc}\n")
+
+
+def sweep_stale_auto_worktrees(parent_repo: str, repo_name: str, parent_dir: str) -> None:
+    """前回実行の残骸（worktree 登録・空ディレクトリ）を掃除する。
+
+    Windows のロックで `git worktree remove --force` が rmdir 段階だけ失敗すると（#245）、
+    worktree 登録は解除済みの空ディレクトリが残る。ロックはセッション終了で解放されるため、
+    次回実行の本掃除で確実に収束させる。中身のあるディレクトリは未リカバリの生成記事を
+    含みうるため削除せず、警告のみ出す（サイレントに消さない）。
+    """
+    _run(["git", "-C", parent_repo, "worktree", "prune"])
+    prefix = f"{repo_name}-wt-auto-"
+    try:
+        entries = os.listdir(parent_dir)
+    except OSError as exc:
+        sys.stderr.write(f"WARNING: 残骸掃除のディレクトリ走査に失敗（続行）: {exc}\n")
+        return
+    removed_any = False
+    for name in sorted(entries):
+        if not name.startswith(prefix):
+            continue
+        path = os.path.join(parent_dir, name)
+        if not os.path.isdir(path):
+            continue
+        try:
+            if os.listdir(path):
+                print(f"WARNING: 前回残骸の worktree が非空のため削除しません: {path}")
+                continue
+            os.rmdir(path)
+            removed_any = True
+            print(f"[PHASE environment] 前回残骸の空 worktree ディレクトリを削除: {path}")
+        except OSError as exc:
+            sys.stderr.write(f"WARNING: 残骸ディレクトリの削除に失敗（続行）: {path}: {exc}\n")
+    # 「登録が残存したままの空ディレクトリ」型の残骸では、rmdir によって初めて登録が
+    # ダングリングし prune 対象になるため、削除後にもう一度 prune する
+    if removed_any:
+        _run(["git", "-C", parent_repo, "worktree", "prune"])
+
+
 # ---------------------------------------------------------------------------
 # Phase 2〜5: finalize
 # ---------------------------------------------------------------------------
-def _resolve_context() -> tuple[str, str, str]:
-    """worktree 内から parent_repo / worktree_path / branch_name を git 経由で導出する。"""
-    worktree_path = _run(["git", "rev-parse", "--show-toplevel"]).stdout.strip()
-    common_dir = _run(["git", "rev-parse", "--git-common-dir"]).stdout.strip()
+def _fallback_parent_repo() -> str:
+    """コンテキスト導出に失敗したとき、result.json の書き先とする親リポを cwd から求める。
+
+    cwd が親リポでも worktree 内でも `--git-common-dir` は親リポの `.git` を指す。
+    git 管理外なら cwd を返す（best effort。書けないよりは cwd 直下に残す方が診断できる）。
+    """
+    common = _run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]
+    ).stdout.strip()
+    if common:
+        return os.path.dirname(os.path.realpath(common))
+    return os.getcwd()
+
+
+def _resolve_context(worktree: str | None = None) -> tuple[str, str, str]:
+    """parent_repo / worktree_path / branch_name を git 経由で導出する。
+
+    `worktree` 指定時はそのパスを基準に導出する（cwd は問わない）。省略時は従来通り
+    cwd（worktree 内での起動を想定）から導出する。
+
+    Raises:
+        RuntimeError: git rev-parse の失敗・出力空（git 管理外のディレクトリ等）。
+            prune 済み残骸に `--worktree` を向けた場合などに該当し、放置すると
+            parent_repo が誤導出されて result.json が不可視の場所に書かれるため、
+            呼び出し元（cmd_finalize）で failed_phase=environment に合流させる
+    """
+    if worktree is not None:
+        worktree_path = os.path.realpath(worktree)
+        base = ["git", "-C", worktree_path, "rev-parse"]
+    else:
+        worktree_path = _run(["git", "rev-parse", "--show-toplevel"]).stdout.strip()
+        if not worktree_path:
+            raise RuntimeError("cwd が git 管理外です（--worktree 指定か worktree 内で起動）")
+        base = ["git", "rev-parse"]
+    common_proc = _run([*base, "--path-format=absolute", "--git-common-dir"])
+    common_dir = common_proc.stdout.strip()
+    if common_proc.returncode != 0 or not common_dir:
+        raise RuntimeError(
+            f"git リポジトリを解決できません: {worktree_path}"
+            f"（{_summarize_stderr(common_proc.stderr) or 'git rev-parse 出力空'}）"
+        )
+    branch_proc = _run([*base, "--abbrev-ref", "HEAD"])
+    branch_name = branch_proc.stdout.strip()
+    if branch_proc.returncode != 0 or not branch_name:
+        raise RuntimeError(
+            f"ブランチ名を解決できません: {worktree_path}"
+            f"（{_summarize_stderr(branch_proc.stderr) or 'git rev-parse 出力空'}）"
+        )
     parent_repo = os.path.dirname(os.path.realpath(common_dir))
-    branch_name = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
     return parent_repo, worktree_path, branch_name
 
 
-def cmd_finalize(article_path: str) -> int:
-    parent_repo, worktree_path, branch_name = _resolve_context()
+def cmd_finalize(article_path: str, worktree: str | None = None) -> int:
+    # --worktree の指定パスが実在しない場合、そのパスからは何も導出できないため、
+    # cwd（親リポ想定）から parent_repo を求めて result.json を書いた上で失敗終了する
+    if worktree is not None and not os.path.isdir(worktree):
+        state = PublishState(parent_repo=_fallback_parent_repo())
+        fail(
+            state,
+            failed_phase="environment",
+            error=f"--worktree のパスが存在しません: {worktree}",
+        )
+
+    try:
+        parent_repo, worktree_path, branch_name = _resolve_context(worktree)
+    except RuntimeError as exc:
+        state = PublishState(parent_repo=_fallback_parent_repo())
+        fail(state, failed_phase="environment", error=str(exc))
     state = PublishState(
         parent_repo=parent_repo,
         worktree_path=worktree_path,
         branch_name=branch_name,
     )
+
+    # publish_hatena は `__file__` 基準でリポジトリルート（.env / published.jsonl）を解決する。
+    # 親リポ側のスクリプトを起動すると読み先が worktree とズレて Phase 2 の URL 組み立てが
+    # 破綻するため、worktree 側の scripts/ から起動されていることを検証する
+    if os.path.normcase(os.path.realpath(str(publish_hatena.REPO_ROOT))) != os.path.normcase(
+        os.path.realpath(worktree_path)
+    ):
+        fail(
+            state,
+            failed_phase="environment",
+            error=(
+                "finalize は worktree 側の scripts/auto_publish_diary.py を起動してください"
+                f"（script root: {publish_hatena.REPO_ROOT} / worktree: {worktree_path}）"
+            ),
+        )
 
     # Phase 1（記事生成）の成否はここで判定する。article_path が空・不在なら write 失敗扱い
     if not article_path or not (pathlib.Path(worktree_path) / article_path).is_file():
@@ -448,9 +610,10 @@ def cleanup(
         + `worktree_remove_error` 非 null の組み合わせを「rmdir フォールバック発動」
         のシグナルとして残し、根本原因の継続観測を可能にする）。
     """
-    # finalize は worktree を cwd として起動される。Windows では cwd が worktree 内に
-    # ある間はディレクトリを削除できないため、remove 前に親リポへ chdir して cwd ロックを
-    # 解放する（git 呼び出し自体は -C で repo を指定済み。chdir は OS の cwd ロック対策）。
+    # finalize が worktree を cwd として起動された場合（--worktree 省略のレガシー経路）、
+    # Windows では cwd が worktree 内にある間はディレクトリを削除できないため、remove 前に
+    # 親リポへ chdir して cwd ロックを解放する（親リポ cwd 起動時は no-op 相当。
+    # git 呼び出し自体は -C で repo を指定済み。chdir は OS の cwd ロック対策）。
     os.chdir(parent_repo)
     remove_proc = _run(
         ["git", "-C", parent_repo, "worktree", "remove", "--force", worktree_path]
@@ -529,11 +692,16 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser("setup", help="Phase 0: 環境準備・worktree 作成")
     p_fin = sub.add_parser("finalize", help="Phase 2〜5: 投稿・git・PR・merge・cleanup")
     p_fin.add_argument("--article-path", required=True, help="生成記事の worktree 相対パス")
+    p_fin.add_argument(
+        "--worktree",
+        default=None,
+        help="worktree の絶対パス（指定時は親リポ等どこからでも起動可。省略時は cwd から導出）",
+    )
     args = parser.parse_args(argv)
 
     if args.command == "setup":
         return cmd_setup()
-    return cmd_finalize(args.article_path)
+    return cmd_finalize(args.article_path, args.worktree)
 
 
 if __name__ == "__main__":

--- a/scripts/write_auto_publish_result.py
+++ b/scripts/write_auto_publish_result.py
@@ -39,6 +39,22 @@ import pathlib
 import sys
 import tempfile
 
+# in-flight マーカー: setup 成功時に作成され、result.json 書き込みで削除される。
+# 「マーカーあり + result.json 不在」= 生成〜finalize 間で実行が途切れた状態を表し、
+# Stop hook（.claude/scripts/auto-publish-stop-guard.sh）が finalize 未実行の検出に使う
+IN_FLIGHT_FILENAME = "in-flight"
+# Stop hook のブロック回数カウンタ。setup でリセットし、result.json 書き込みで削除する
+STOP_BLOCK_COUNT_FILENAME = "stop-block-count"
+# 自動投稿セッションの自己識別ファイル。setup が自セッションの CLAUDE_CODE_SESSION_ID を
+# 記録し、Stop hook は「記録された ID と自分のセッション ID が一致するときだけ」ブロックする
+# （並行する開発セッションを誤ブロックしないため）。result.json 書き込みで削除する
+SESSION_ID_FILENAME = "session-id"
+
+
+def result_dir(parent_repo: str) -> pathlib.Path:
+    """result.json・in-flight マーカー等を配置する状態ディレクトリを返す."""
+    return pathlib.Path(parent_repo) / ".tmp" / "auto-publish-diary"
+
 
 def build_result(
     *,
@@ -113,10 +129,14 @@ def write_result_file(parent_repo: str, result: dict) -> None:
     書き込み途中のプロセス中断・ディスクフル等でも、既存 result.json の完全性を保つ
     （publish_hatena.py の published.jsonl 更新と同じパターン）。
 
+    書き込み成功後、in-flight マーカー・Stop hook カウンタ・session-id を削除する
+    （result.json が書かれた = 実行が終端に到達したため、Stop hook のブロック対象から外す）。
+    マーカー削除の失敗は結果伝達に影響しないため握りつぶす。
+
     Raises:
         OSError: ディレクトリ作成・テンポラリ作成・書き込み・置換のいずれか失敗時
     """
-    target_dir = pathlib.Path(parent_repo) / ".tmp" / "auto-publish-diary"
+    target_dir = result_dir(parent_repo)
     target_dir.mkdir(parents=True, exist_ok=True)
     target = target_dir / "result.json"
     payload = json.dumps(result, ensure_ascii=False) + "\n"
@@ -131,6 +151,11 @@ def write_result_file(parent_repo: str, result: dict) -> None:
         except OSError:
             pass
         raise
+    for name in (IN_FLIGHT_FILENAME, STOP_BLOCK_COUNT_FILENAME, SESSION_ID_FILENAME):
+        try:
+            (target_dir / name).unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def validate(args: argparse.Namespace) -> str | None:

--- a/tests/test_auto_publish_diary.py
+++ b/tests/test_auto_publish_diary.py
@@ -351,6 +351,224 @@ class CleanupTest(unittest.TestCase):
         sleep_mock.assert_not_called()
 
 
+class SweepStaleAutoWorktreesTest(unittest.TestCase):
+    """setup の前回残骸掃除（#245 の翌日収束用の安全網）を検証する。"""
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.parent_dir = pathlib.Path(self.tmpdir.name)
+        self.parent_repo = self.parent_dir / "article-writer"
+        self.parent_repo.mkdir()
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def _sweep(self) -> mock.MagicMock:
+        with mock.patch.object(auto_publish_diary, "_run") as run_mock:
+            auto_publish_diary.sweep_stale_auto_worktrees(
+                str(self.parent_repo), "article-writer", str(self.parent_dir)
+            )
+        return run_mock
+
+    def test_prunes_worktree_registrations(self) -> None:
+        run_mock = self._sweep()
+        run_mock.assert_called_once_with(
+            ["git", "-C", str(self.parent_repo), "worktree", "prune"]
+        )
+
+    def test_removes_empty_stale_dirs_only(self) -> None:
+        empty_stale = self.parent_dir / "article-writer-wt-auto-20260716"
+        empty_stale.mkdir()
+        nonempty_stale = self.parent_dir / "article-writer-wt-auto-20260715"
+        nonempty_stale.mkdir()
+        (nonempty_stale / "articles").mkdir()
+        unrelated = self.parent_dir / "article-writer-wt-123"
+        unrelated.mkdir()
+
+        self._sweep()
+
+        self.assertFalse(empty_stale.exists(), "空の残骸は削除される")
+        self.assertTrue(nonempty_stale.exists(), "非空の残骸は未リカバリ記事保護のため残す")
+        self.assertTrue(unrelated.exists(), "auto 以外の worktree ディレクトリは対象外")
+
+    def test_ignores_matching_files(self) -> None:
+        stray_file = self.parent_dir / "article-writer-wt-auto-20260716"
+        stray_file.write_text("not a dir", encoding="utf-8")
+        self._sweep()
+        self.assertTrue(stray_file.exists())
+
+    def test_prunes_again_after_removing_dirs(self) -> None:
+        """空ディレクトリを削除した場合、ダングリング登録を刈るため prune を再実行する。"""
+        (self.parent_dir / "article-writer-wt-auto-20260716").mkdir()
+        run_mock = self._sweep()
+        prune_cmd = ["git", "-C", str(self.parent_repo), "worktree", "prune"]
+        self.assertEqual(
+            [c.args[0] for c in run_mock.call_args_list], [prune_cmd, prune_cmd]
+        )
+
+
+class CreateInFlightMarkerTest(unittest.TestCase):
+    """setup 成功時のマーカー作成・カウンタリセット・セッション ID 記録（Stop hook ガードの前提）を検証する。"""
+
+    def test_creates_marker_and_resets_counter_and_records_session_id(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = pathlib.Path(d) / ".tmp" / "auto-publish-diary"
+            state_dir.mkdir(parents=True)
+            counter = state_dir / "stop-block-count"
+            counter.write_text("2\n", encoding="utf-8")
+
+            with mock.patch.dict(
+                auto_publish_diary.os.environ,
+                {"CLAUDE_CODE_SESSION_ID": "sid-12345"},
+            ):
+                auto_publish_diary.create_in_flight_marker(d, "2026-07-17T04:30:00")
+
+            marker = state_dir / "in-flight"
+            self.assertEqual(
+                marker.read_text(encoding="utf-8"), "2026-07-17T04:30:00\n"
+            )
+            self.assertFalse(counter.exists(), "前回カウンタはリセット（削除）される")
+            self.assertEqual(
+                (state_dir / "session-id").read_text(encoding="utf-8"), "sid-12345\n"
+            )
+
+    def test_removes_stale_session_id_when_env_missing(self) -> None:
+        """env 不在（claude 外の手動実行等）では記録せず、前回残骸の古い ID も残さない。
+
+        古い ID が残ると無関係セッションの誤ブロックにつながるため、必ず消してから判定する。
+        """
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = pathlib.Path(d) / ".tmp" / "auto-publish-diary"
+            state_dir.mkdir(parents=True)
+            stale = state_dir / "session-id"
+            stale.write_text("old-sid\n", encoding="utf-8")
+
+            env = {
+                k: v
+                for k, v in auto_publish_diary.os.environ.items()
+                if k != "CLAUDE_CODE_SESSION_ID"
+            }
+            with mock.patch.dict(auto_publish_diary.os.environ, env, clear=True):
+                auto_publish_diary.create_in_flight_marker(d, "2026-07-17T04:30:00")
+
+            self.assertFalse(stale.exists())
+            self.assertTrue((state_dir / "in-flight").exists())
+
+
+class ResolveContextTest(unittest.TestCase):
+    """finalize --worktree 指定時のコンテキスト導出（親リポ cwd からの起動対応）を検証する。"""
+
+    def _make_proc(self, stdout: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    def test_resolves_from_worktree_arg_with_absolute_common_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            parent = pathlib.Path(d) / "article-writer"
+            worktree = pathlib.Path(d) / "article-writer-wt-auto-20260717"
+            worktree.mkdir()
+            common_dir = str(parent / ".git")
+            with mock.patch.object(auto_publish_diary, "_run") as run_mock:
+                run_mock.side_effect = [
+                    self._make_proc(common_dir + "\n"),
+                    self._make_proc("auto/diary-2026-07-17\n"),
+                ]
+                parent_repo, worktree_path, branch = auto_publish_diary._resolve_context(
+                    str(worktree)
+                )
+            self.assertEqual(parent_repo, str(parent))
+            self.assertEqual(worktree_path, str(worktree.resolve()))
+            self.assertEqual(branch, "auto/diary-2026-07-17")
+            # git 呼び出しは -C <worktree> 基準で行われる（cwd 非依存）
+            self.assertEqual(
+                run_mock.call_args_list[0].args[0][:3], ["git", "-C", str(worktree.resolve())]
+            )
+
+    def test_raises_when_worktree_is_not_a_git_repo(self) -> None:
+        """prune 済み残骸等の git 管理外ディレクトリで parent_repo が誤導出されない。
+
+        検査なしだと realpath("") = cwd 起点で親リポの一つ上に誤導出され、result.json が
+        不可視の場所に書かれる（code-review 指摘）。RuntimeError で environment 失敗に合流させる。
+        """
+        with tempfile.TemporaryDirectory() as d:
+            for proc in (
+                self._make_proc(""),  # returncode 0 でも出力空
+                subprocess.CompletedProcess(
+                    args=[], returncode=128, stdout="", stderr="fatal: not a git repository"
+                ),
+            ):
+                with mock.patch.object(auto_publish_diary, "_run", return_value=proc):
+                    with self.assertRaises(RuntimeError):
+                        auto_publish_diary._resolve_context(d)
+
+    def test_raises_when_branch_name_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(auto_publish_diary, "_run") as run_mock:
+                run_mock.side_effect = [
+                    self._make_proc(str(pathlib.Path(d) / ".git") + "\n"),
+                    self._make_proc(""),
+                ]
+                with self.assertRaises(RuntimeError):
+                    auto_publish_diary._resolve_context(d)
+
+
+class FinalizeGuardTest(unittest.TestCase):
+    """cmd_finalize の起動ミス検出ガード（--worktree 不在 / スクリプト起動元ズレ）を検証する。"""
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.parent_repo = pathlib.Path(self.tmpdir.name)
+        self.result_path = (
+            self.parent_repo / ".tmp" / "auto-publish-diary" / "result.json"
+        )
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def _read(self) -> dict:
+        return json.loads(self.result_path.read_text(encoding="utf-8"))
+
+    def test_fails_environment_when_worktree_path_missing(self) -> None:
+        missing = str(self.parent_repo / "no-such-worktree")
+        with mock.patch.object(auto_publish_diary, "_run") as run_mock:
+            # _fallback_parent_repo の --git-common-dir 呼び出しに親リポの .git を返す
+            run_mock.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=str(self.parent_repo / ".git") + "\n", stderr=""
+            )
+            with self.assertRaises(SystemExit) as cm:
+                auto_publish_diary.cmd_finalize("articles/hatena/x.md", worktree=missing)
+        self.assertEqual(cm.exception.code, 1)
+        data = self._read()
+        self.assertEqual(data["status"], "error")
+        self.assertEqual(data["failed_phase"], "environment")
+        self.assertIn("no-such-worktree", data["error"])
+
+    def test_fails_environment_when_script_root_mismatches_worktree(self) -> None:
+        """親リポ側スクリプト起動の取り違え（publish_hatena の読み先ズレ）を検出する。"""
+        worktree = self.parent_repo / "wt"
+        worktree.mkdir()
+        with (
+            mock.patch.object(
+                auto_publish_diary,
+                "_resolve_context",
+                return_value=(str(self.parent_repo), str(worktree), "auto/diary-x"),
+            ),
+            mock.patch.object(
+                auto_publish_diary.publish_hatena,
+                "REPO_ROOT",
+                self.parent_repo / "elsewhere",
+            ),
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                auto_publish_diary.cmd_finalize(
+                    "articles/hatena/x.md", worktree=str(worktree)
+                )
+        self.assertEqual(cm.exception.code, 1)
+        data = self._read()
+        self.assertEqual(data["status"], "error")
+        self.assertEqual(data["failed_phase"], "environment")
+        self.assertIn("worktree 側の scripts/auto_publish_diary.py", data["error"])
+
+
 class SummarizeStderrTest(unittest.TestCase):
     def test_returns_none_for_empty(self) -> None:
         self.assertIsNone(auto_publish_diary._summarize_stderr(None))

--- a/tests/test_write_auto_publish_result.py
+++ b/tests/test_write_auto_publish_result.py
@@ -344,6 +344,45 @@ class BuildResultFunctionTest(unittest.TestCase):
             leftover = list(target.parent.glob(".result.json.*"))
             self.assertEqual(leftover, [])
 
+    def test_write_result_file_removes_in_flight_marker_and_counter(self) -> None:
+        """result.json 書き込みで in-flight マーカーと Stop hook カウンタが削除される。
+
+        「マーカーあり + result.json 不在」= finalize 未到達、を成立させるための終端処理。
+        status=ok / error のどちらの書き込みでも削除されることを担保する。
+        """
+        for status_kwargs in (
+            {"status": "ok", "article_path": "a.md", "edit_url": "https://e",
+             "public_url": "https://p", "pr_url": "https://pr", "worktree_removed": True},
+            {"status": "error", "failed_phase": "write", "error": "生成失敗"},
+        ):
+            with self.subTest(status=status_kwargs["status"]), tempfile.TemporaryDirectory() as d:
+                state_dir = write_auto_publish_result.result_dir(d)
+                state_dir.mkdir(parents=True)
+                marker = state_dir / write_auto_publish_result.IN_FLIGHT_FILENAME
+                counter = state_dir / write_auto_publish_result.STOP_BLOCK_COUNT_FILENAME
+                session = state_dir / write_auto_publish_result.SESSION_ID_FILENAME
+                marker.write_text("2026-07-17T04:30:00\n", encoding="utf-8")
+                counter.write_text("1\n", encoding="utf-8")
+                session.write_text("sid-12345\n", encoding="utf-8")
+
+                result = write_auto_publish_result.build_result(**status_kwargs)
+                write_auto_publish_result.write_result_file(d, result)
+
+                self.assertTrue((state_dir / "result.json").exists())
+                self.assertFalse(marker.exists(), f"status={status_kwargs['status']}")
+                self.assertFalse(counter.exists(), f"status={status_kwargs['status']}")
+                self.assertFalse(session.exists(), f"status={status_kwargs['status']}")
+
+    def test_write_result_file_succeeds_without_marker_files(self) -> None:
+        """マーカー・カウンタが存在しなくても write_result_file は正常終了する。"""
+        with tempfile.TemporaryDirectory() as d:
+            result = write_auto_publish_result.build_result(
+                status="error", failed_phase="environment", error="e"
+            )
+            write_auto_publish_result.write_result_file(d, result)
+            target = write_auto_publish_result.result_dir(d) / "result.json"
+            self.assertTrue(target.exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Change type

- [x] fix

## Summary

- **finalize 未実行ガード（Stop hook）**: 記事生成（長い LLM ステップ）後の end_turn 打ち切りで finalize（Hatena 投稿・PR・result.json）が丸ごと飛ぶ問題（2026-07-17 発生）への L2 ガード。setup が in-flight マーカー + 自セッション ID を記録し、Stop hook が「マーカーあり + result.json 不在」の停止をブロックして finalize 実行を指示する（記録セッションのみ対象・2 時間上限・最大 2 回の fail-open 設計で並行セッションへの誤爆なし）
- **worktree 残骸掃除**: Windows ロックで `git worktree remove` が失敗し続ける問題（#245 系）への安全網。setup が前回残骸（空の `*-wt-auto-*` ディレクトリ）を削除 + `git worktree prune`。非空残骸は未リカバリ記事保護のため警告のみ
- **finalize の cwd 依存解消**: `--worktree` 引数を追加し、SKILL.md 手順を「親リポへ cd 復帰してから worktree 側スクリプトで finalize」に変更（削除ロック要因の低減・後方互換維持）。git 管理外パス・起動スクリプト取り違えのガードも追加
- `.gitattributes` で `*.sh` を LF 固定（autocrlf 環境での hook 破損防止）
- ai-assistant 側インターフェース（`claude -p` 起動 / exit code / result.json スキーマ）は不変

## Test plan

- [x] unittest 218 件パス（マーカーライフサイクル・掃除・`--worktree` 解決・失敗経路のテスト追加）
- [x] shellcheck パス / markdownlint 0 issues
- [x] Stop hook は擬似リポジトリで全分岐（ブロック 2 回上限・2h 超・result.json 有無・セッション照合 4 分岐）の実挙動を確認
- [ ] 実運用（次回定時実行）で hook 発火と worktree 削除成否を result.json で観測（手動 QA）

## Related issues

なし（トピックモード: auto-publish-guard）。関連する過去対応: #234 / #240 / #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)