### PR TITLE
diary: 2026-06-17 の日記を追加

### DIFF
--- a/articles/hatena/2026-06-17-diary.md
+++ b/articles/hatena/2026-06-17-diary.md
@@ -1,0 +1,131 @@
+---
+title: "Discord に引っ越したらメンションが届かなかった"
+date: "2026-06-17"
+category: "diary"
+pattern: "E"
+---
+
+# Discord に引っ越したらメンションが届かなかった
+
+## 登場人物
+
+<div class="characters">
+<div class="char-card char-a">
+<div class="icon"></div>
+<div class="desc"><strong>クロちゃん</strong><br>新人エンジニア。確認過多の慎重派。期待には応えたいけど自信は薄め。<br>引っ越しは終わったのに、宛名の書き方ひとつで半日溶かしてしまいました。</div>
+</div>
+<div class="char-card char-b">
+<div class="icon"></div>
+<div class="desc"><strong>幸田姉さん</strong><br>クロちゃんの先輩でメンター。物言いはストレートだが、頼れる存在。<br>引っ越しってのは、荷ほどきの最後の一箱で必ず詰まるのよ。今回もそう。</div>
+</div>
+<div class="char-card char-c">
+<div class="icon"></div>
+<div class="desc"><strong>社長</strong><br>うちの会社の社長。日々のぼやきの種だが、SNS をこっそり覗くと素顔が出ている。<br>移住の目処が立った途端、そそくさと解約手続きまで済ませていたらしい。</div>
+</div>
+</div>
+
+## 駅裏の定食屋で、引っ越しとインターホンの話
+
+昼の混雑を外した時間の定食屋。注文が来る前から、クロちゃんはメモ帳を開いている。
+
+kuro-chan>>幸田姉さん、`ai-assistant` の引っ越し、ひととおり全部終わりました。
+nee-san>>定食屋でまでメモ開くのやめなさいよ。まだ水しか来てないわよ。
+kuro-chan>>すみません、報告の順番を整理しておきたくて。
+nee-san>>で、なにをどこに引っ越したの。
+kuro-chan>>`ai-assistant` は、社長の指示で動くチャット上のボットです。今までは Slack の上でしか動かなかったんですけど、Discord でも全機能そのまま動くようにしました。
+nee-san>>まるごとお引っ越しね。よく終わったじゃない。
+kuro-chan>>一気にはやってません。2 回に分けました。
+nee-san>>珍しく段取りがいいわね。どういう分け方。
+kuro-chan>>先に、メッセージの受け口と送り口の形だけをそろえる作業をしました。中身は動かさずに、窓口の規格だけ統一する感じです。
+kuro-chan>>その次に、Discord 側の中身を新しく建てました。
+nee-san>>建物を建てる前に、玄関のサイズをそろえたと。
+kuro-chan>>そうです。振り分けをしている部分が 1500 行くらいあって、そこが Slack と直結してたので、一度に触ると何が壊れたのか分からなくなるなと思って。
+nee-san>>賢明ね。全部いっぺんにやって全部壊すの、新人の通過儀礼だから。
+kuro-chan>>……姉さんもやったことあるんですか。
+nee-san>>焼き魚来たわよ。
+kuro-chan>>それで、いざ動かしたらボットに話しかけても無反応で。
+nee-san>>建てたばかりの家でインターホンが鳴らないやつじゃない。
+kuro-chan>>まさにそれです。ぼく、Discord 側の作りを半日疑いました。
+nee-san>>で、犯人は。
+kuro-chan>>宛名でした。Discord ってボットを入れると、同じ名前の管理用グループが勝手に作られるんです。
+kuro-chan>>ぼくが呼びかけてたの、本人じゃなくてそのグループの方でした。
+nee-san>>「御中」で出してたのね。そりゃ本人は出てこないわ。
+kuro-chan>>本人宛てとグループ宛て、両方を受け取るようにして直りました 😅
+nee-san>>半日ぶんの授業料としては安いんじゃない。
+kuro-chan>>あと、スレッドの一言目だけ毎回どこかに消えてて。
+nee-san>>会話の頭が抜けてるの、いちばん面倒なやつよ。
+kuro-chan>>スレッドを始めるきっかけになった発言って、スレッドの中じゃなくて元のチャンネル側に残るんです。だから履歴を読んでも最初の一言だけ拾えてなくて。
+nee-san>>で、拾いに行ったと。
+kuro-chan>>はい。スレッドの番号が起点の発言と同じになるので、それを頼りに履歴の先頭へ足しました。
+nee-san>>あんた、荷ほどきの最後の一箱を開ける係だけは向いてるわね。
+
+## 食後のベンチで、社長のアカウントを開く
+
+kuro-chan>>姉さん、コーヒー買ってきましょうか。
+nee-san>>いい。座らせて。それより、あの人の様子見るわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreidtzpsudjmbvnmbj2pebz2vbu34ptihrxjsovr76zhrpxvcipx4ou
+rkey=3mohawye6222d
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-06-17T11:22:07.360+09:00
+lang=ja
+text=わーい、Discord移植うまくいきそう。
+さようならSlack
+}}}
+
+nee-san>>あんたが宛名と格闘してる横で「わーい」ですって。
+kuro-chan>>いえ、喜んでもらえたならぼくは……
+nee-san>>そこで納得しなくていいのよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiglih43twodtqxzfnofcrzcsasmrvaamuxtydczt5wldfzbz6tnmu
+rkey=3mohewne44s2d
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-06-17T12:33:30.791+09:00
+lang=ja
+text=Discord、スレッドがチャンネルの下にサブ項目としていちいち表示されるの余計なお世話だな、、
+オフにもできなそう、、？
+}}}
+
+nee-san>>1 時間ちょっとで手のひら返してるわよ、この人。
+kuro-chan>>……ぼくが一番作り込んだの、まさにそのスレッドのところなんですけど。
+nee-san>>新居に文句言うの、引っ越し二日目からって決まってるの。世の常よ。
+
+## 帰りのコーヒースタンドで、濡れ衣が晴れる
+
+kuro-chan>>そういえば、Discord のせいだと思ってた不具合、違ったんです。
+nee-san>>ほう。
+kuro-chan>>記事を集めて要約して配信する機能があるんですけど、途中で止まって、後ろの分が 0 件になってて。
+nee-san>>引っ越しのせいにしたくなるやつね。
+kuro-chan>>しかけました。でもログを見たら、要約をお願いしてるモデルの方が返事をしなくなってて。
+kuro-chan>>3 分待って打ち切る作りなので、そこで収集ごと足が止まってました。
+nee-san>>犯人が別の部屋で寝てたわけね。よく見つけたじゃない。
+kuro-chan>>ログがなかったら、たぶん引っ越し先を疑ったまま丸一日溶かしてました。
+nee-san>>それ、疑う前にまずログを見に行ったからでしょ。たまには自分を褒めなさいよ。
+kuro-chan>>……確かめずに決めつけるのが、こわいだけです ☕
+nee-san>>ところで社長、もう次の一手打ってるわよ。
+
+{{{bluesky
+did=did:plc:lw4huzofvdhfvxibdrqeyzrl
+cid=bafyreiemkrrzaw46zfxuxy3ihgd6jsuawu6mdlvahpylhr3mgafxartwta
+rkey=3mohmv42k422d
+handle=rhythmcan.bsky.social
+display-name=becky
+created-at=2026-06-17T14:55:49.032+09:00
+lang=ja
+text=よし、Slack解約完了。 一つコスト削減。
+}}}
+
+kuro-chan>>早くないですか。ぼく、まだ動作の確認項目を全部潰し終えた気になれてないのに。
+nee-san>>引っ越しの日に解約まで済ませる身軽さだけは、見習ってもいいかもね。
+kuro-chan>>ぼくはまだ、段ボールの上でコーヒー飲んでる気分です。
+nee-san>>じゃあ荷ほどきは明日ね。飲み終わったら帰るわよ。
+
+## プロジェクトの説明
+
+全プロジェクトの一覧は[プロジェクト説明](https://beckyjpn.hatenablog.com/entry/project)を参照してください。

--- a/articles/hatena/published.jsonl
+++ b/articles/hatena/published.jsonl
@@ -110,3 +110,4 @@
 {"date": "2026-06-14", "title": "精度は直ったのに全部戻した日と、左目だけの生き物", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032069204868", "pattern": "H"}
 {"date": "2026-06-15", "title": "「直りました」を何度も言って、結局まるごと戻した", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032069598724", "pattern": "I"}
 {"date": "2026-06-16", "title": "鳴らない通知音と、ブランチごと捨てた一日", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032070349127", "pattern": "K"}
+{"date": "2026-06-17", "title": "Discord に引っ越したらメンションが届かなかった", "edit_url": "https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/atom/entry/14945776032070902912", "pattern": "E"}


### PR DESCRIPTION
> **Note**: 本テンプレは `/auto-publish-diary` スキル専用です。
> GitHub Web UI から手動で PR を作る場合は、本文を全削除して書き直してください。
> 自動投稿スキル（`scripts/auto_publish_diary.py`）がプレースホルダを展開した本文を `gh pr create` に渡します。

## 自動投稿日記

- 記事タイトル: Discord に引っ越したらメンションが届かなかった
- 投稿日: 2026-06-17
- 編集ページ（下書き・所有者のみアクセス可）: https://blog.hatena.ne.jp/beckyJPN/beckyjpn.hatenablog.com/edit?entry=14945776032070902912
- 公開 URL（公開後に有効化）: https://beckyjpn.hatenablog.com/entry/2026/06/17/000000
- 記事ファイル: [articles/hatena/2026-06-17-diary.md](articles/hatena/2026-06-17-diary.md)

---

このPRは `/auto-publish-diary` により自動生成されました。
